### PR TITLE
MAPREDUCE-7421. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-jobclient.

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/conf/TestNoDefaultsJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/conf/TestNoDefaultsJobConf.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
 import org.apache.hadoop.mapred.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -39,8 +39,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This testcase tests that a JobConf without default values submits jobs
@@ -56,10 +55,10 @@ public class TestNoDefaultsJobConf extends HadoopTestCase {
   @Test
   public void testNoDefaults() throws Exception {
     JobConf configuration = new JobConf();
-    assertTrue(configuration.get("hadoop.tmp.dir", null) != null);
+    assertNotNull(configuration.get("hadoop.tmp.dir", null));
 
     configuration = new JobConf(false);
-    assertTrue(configuration.get("hadoop.tmp.dir", null) == null);
+    assertNull(configuration.get("hadoop.tmp.dir", null));
 
 
     Path inDir = new Path("testing/jobconf/input");
@@ -96,8 +95,8 @@ public class TestNoDefaultsJobConf extends HadoopTestCase {
     JobClient.runJob(conf);
 
     Path[] outputFiles = FileUtil.stat2Paths(
-                           getFileSystem().listStatus(outDir,
-                           new Utils.OutputFileUtils.OutputFilesFilter()));
+        getFileSystem().listStatus(outDir,
+        new Utils.OutputFileUtils.OutputFilesFilter()));
     if (outputFiles.length > 0) {
       InputStream is = getFileSystem().open(outputFiles[0]);
       BufferedReader reader = new BufferedReader(new InputStreamReader(is));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/DFSCIOTest.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/DFSCIOTest.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
 import org.apache.hadoop.mapred.*;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestDFSIO.java
@@ -66,9 +66,10 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +227,7 @@ public class TestDFSIO implements Tool {
   private static MiniDFSCluster cluster;
   private static TestDFSIO bench;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     bench = new TestDFSIO();
     bench.getConf().setInt(DFSConfigKeys.DFS_HEARTBEAT_INTERVAL_KEY, 1);
@@ -241,7 +242,7 @@ public class TestDFSIO implements Tool {
     testWrite();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws Exception {
     if(cluster == null)
       return;
@@ -256,14 +257,16 @@ public class TestDFSIO implements Tool {
     bench.analyzeResult(fs, TestType.TEST_TYPE_WRITE, execTime);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testRead() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     long execTime = bench.readTest(fs);
     bench.analyzeResult(fs, TestType.TEST_TYPE_READ, execTime);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testReadRandom() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     bench.getConf().setLong("test.io.skip.size", 0);
@@ -271,7 +274,8 @@ public class TestDFSIO implements Tool {
     bench.analyzeResult(fs, TestType.TEST_TYPE_READ_RANDOM, execTime);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testReadBackward() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     bench.getConf().setLong("test.io.skip.size", -DEFAULT_BUFFER_SIZE);
@@ -279,7 +283,8 @@ public class TestDFSIO implements Tool {
     bench.analyzeResult(fs, TestType.TEST_TYPE_READ_BACKWARD, execTime);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testReadSkip() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     bench.getConf().setLong("test.io.skip.size", 1);
@@ -287,14 +292,16 @@ public class TestDFSIO implements Tool {
     bench.analyzeResult(fs, TestType.TEST_TYPE_READ_SKIP, execTime);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testAppend() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     long execTime = bench.appendTest(fs);
     bench.analyzeResult(fs, TestType.TEST_TYPE_APPEND, execTime);
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testTruncate() throws Exception {
     FileSystem fs = cluster.getFileSystem();
     bench.createControlFile(fs, DEFAULT_NR_BYTES / 2, DEFAULT_NR_FILES);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestFileSystem.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestFileSystem.java
@@ -47,16 +47,16 @@ import org.apache.hadoop.mapred.*;
 import org.apache.hadoop.mapred.lib.LongSumReducer;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class TestFileSystem {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestJHLA.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/TestJHLA.java
@@ -23,9 +23,9 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.File;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class TestJHLA {
   private String historyLog = System.getProperty("test.build.data", 
                                   "build/test/data") + "/history/test.log";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     File logFile = new File(historyLog);
     if(!logFile.getParentFile().exists())
@@ -121,7 +121,7 @@ public class TestJHLA {
     writer.close();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     File logFile = new File(historyLog);
     if(!logFile.delete())

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/slive/TestSlive.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/fs/slive/TestSlive.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.fs.slive;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInputStream;
 import java.io.File;
@@ -40,8 +40,8 @@ import org.apache.hadoop.fs.slive.Constants.OperationType;
 import org.apache.hadoop.fs.slive.DataVerifier.VerifyOutput;
 import org.apache.hadoop.fs.slive.DataWriter.GenerateOutput;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -194,7 +194,7 @@ public class TestSlive {
     return extractor;
   }
 
-  @Before
+  @BeforeEach
   public void ensureDeleted() throws Exception {
     rDelete(getTestFile());
     rDelete(getTestDir());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/TestNNBench.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/hdfs/TestNNBench.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,8 +31,9 @@ import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestNNBench extends HadoopTestCase {
   private static final String BASE_DIR =
@@ -45,39 +46,42 @@ public class TestNNBench extends HadoopTestCase {
     super(LOCAL_MR, LOCAL_FS, 1, 1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     getFileSystem().delete(new Path(BASE_DIR), true);
     getFileSystem().delete(new Path(NNBench.DEFAULT_RES_FILE_NAME), true);
     super.tearDown();
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNNBenchCreateReadAndDelete() throws Exception {
     runNNBench(createJobConf(), "create_write");
     Path path = new Path(BASE_DIR + "/data/file_0_0");
-    assertTrue("create_write should create the file",
-        getFileSystem().exists(path));
+    assertTrue(
+       getFileSystem().exists(path), "create_write should create the file");
     runNNBench(createJobConf(), "open_read");
     runNNBench(createJobConf(), "delete");
-    assertFalse("Delete operation should delete the file",
-        getFileSystem().exists(path));
+    assertFalse(
+       getFileSystem().exists(path), "Delete operation should delete the file");
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNNBenchCreateAndRename() throws Exception {
     runNNBench(createJobConf(), "create_write");
     Path path = new Path(BASE_DIR + "/data/file_0_0");
-    assertTrue("create_write should create the file",
-        getFileSystem().exists(path));
+    assertTrue(
+       getFileSystem().exists(path), "create_write should create the file");
     runNNBench(createJobConf(), "rename");
     Path renamedPath = new Path(BASE_DIR + "/data/file_0_r_0");
-    assertFalse("Rename should rename the file", getFileSystem().exists(path));
-    assertTrue("Rename should rename the file",
-        getFileSystem().exists(renamedPath));
+    assertFalse(getFileSystem().exists(path), "Rename should rename the file");
+    assertTrue(
+       getFileSystem().exists(renamedPath), "Rename should rename the file");
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNNBenchCreateControlFilesWithPool() throws Exception {
     runNNBench(createJobConf(), "create_write", BASE_DIR, "5");
     Path path = new Path(BASE_DIR, CONTROL_DIR_NAME);
@@ -86,7 +90,8 @@ public class TestNNBench extends HadoopTestCase {
     assertEquals(5, fileStatuses.length);
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testNNBenchCrossCluster() throws Exception {
     MiniDFSCluster dfsCluster = new MiniDFSCluster.Builder(new JobConf())
             .numDataNodes(1).build();
@@ -96,8 +101,8 @@ public class TestNNBench extends HadoopTestCase {
     runNNBench(createJobConf(), "create_write", baseDir);
 
     Path path = new Path(BASE_DIR + "/data/file_0_0");
-    assertTrue("create_write should create the file",
-            dfsCluster.getFileSystem().exists(path));
+    assertTrue(
+           dfsCluster.getFileSystem().exists(path), "create_write should create the file");
     dfsCluster.shutdown();
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/io/TestSequenceFileMergeProgress.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/io/TestSequenceFileMergeProgress.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.mapred.*;
 
 import org.slf4j.Logger;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSequenceFileMergeProgress {
   private static final Logger LOG = FileInputFormat.LOG;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/ipc/TestMRCJCSocketFactory.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/ipc/TestMRCJCSocketFactory.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
 import org.apache.hadoop.net.StandardSocketFactory;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class checks that RPCs can use specialized socket factories.
@@ -56,13 +56,13 @@ public class TestMRCJCSocketFactory {
 
     // Get a reference to its DFS directly
     FileSystem fs = cluster.getFileSystem();
-    Assert.assertTrue(fs instanceof DistributedFileSystem);
+    Assertions.assertTrue(fs instanceof DistributedFileSystem);
     DistributedFileSystem directDfs = (DistributedFileSystem) fs;
 
     Configuration cconf = getCustomSocketConfigs(nameNodePort);
 
     fs = FileSystem.get(cconf);
-    Assert.assertTrue(fs instanceof DistributedFileSystem);
+    Assertions.assertTrue(fs instanceof DistributedFileSystem);
     DistributedFileSystem dfs = (DistributedFileSystem) fs;
 
     JobClient client = null;
@@ -72,12 +72,12 @@ public class TestMRCJCSocketFactory {
       // could we test Client-DataNode connections?
       Path filePath = new Path("/dir");
 
-      Assert.assertFalse(directDfs.exists(filePath));
-      Assert.assertFalse(dfs.exists(filePath));
+      Assertions.assertFalse(directDfs.exists(filePath));
+      Assertions.assertFalse(dfs.exists(filePath));
 
       directDfs.mkdirs(filePath);
-      Assert.assertTrue(directDfs.exists(filePath));
-      Assert.assertTrue(dfs.exists(filePath));
+      Assertions.assertTrue(directDfs.exists(filePath));
+      Assertions.assertTrue(dfs.exists(filePath));
 
       // This will test RPC to a Resource Manager
       fs = FileSystem.get(sconf);
@@ -95,7 +95,7 @@ public class TestMRCJCSocketFactory {
       client = new JobClient(jconf);
 
       JobStatus[] jobs = client.jobsToComplete();
-      Assert.assertTrue(jobs.length == 0);
+      Assertions.assertTrue(jobs.length == 0);
 
     } finally {
       closeClient(client);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/ClusterMapReduceTestCase.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,7 +64,7 @@ public abstract class ClusterMapReduceTestCase {
    *
    * @throws Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     startCluster(true, null);
   }
@@ -125,7 +125,7 @@ public abstract class ClusterMapReduceTestCase {
    *
    * @throws Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     stopCluster();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/HadoopTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/HadoopTestCase.java
@@ -21,8 +21,8 @@ package org.apache.hadoop.mapred;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.mapreduce.MRConfig;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 
@@ -139,7 +139,7 @@ public abstract class HadoopTestCase {
    *
    * @throws Exception
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     if (localFS) {
       fileSystem = FileSystem.getLocal(new JobConf());
@@ -163,7 +163,7 @@ public abstract class HadoopTestCase {
    *
    * @throws Exception
    */
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     try {
       if (mrCluster != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MRCaching.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/MRCaching.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 
 import java.net.URI;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class MRCaching {
   static String testStr = "This is a test file " + "used for testing caching "
@@ -299,13 +299,13 @@ public class MRCaching {
     String configValues = job.get(configKey, "");
     System.out.println(configKey + " -> " + configValues);
     String[] realSizes = StringUtils.getStrings(configValues);
-    Assert.assertEquals("Number of files for "+ configKey,
-                        expectedSizes.length, realSizes.length);
+    Assertions.assertEquals(
+                       expectedSizes.length, realSizes.length, "Number of files for "+ configKey);
 
     for (int i=0; i < expectedSizes.length; ++i) {
       long actual = Long.valueOf(realSizes[i]);
       long expected = expectedSizes[i];
-      Assert.assertEquals("File "+ i +" for "+ configKey, expected, actual);
+      Assertions.assertEquals(expected, actual, "File "+ i +" for "+ configKey);
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/NotificationTestCase.java
@@ -35,11 +35,11 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.DataOutputStream;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.After;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -132,7 +132,7 @@ public abstract class NotificationTestCase extends HadoopTestCase {
         return;
       }
       failureCounter++;
-      assertTrue("The request (" + query + ") does not contain " + expected, false);
+      assertTrue(false, "The request (" + query + ") does not contain " + expected);
     }
   }
 
@@ -149,13 +149,13 @@ public abstract class NotificationTestCase extends HadoopTestCase {
     return conf;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     startHttpServer();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     stopHttpServer();
     NotificationServlet.counter = 0;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestBadRecords.java
@@ -38,15 +38,15 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.util.ReflectionUtils;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Ignore
 public class TestBadRecords extends ClusterMapReduceTestCase {
   
@@ -61,7 +61,7 @@ public class TestBadRecords extends ClusterMapReduceTestCase {
   
   private List<String> input;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     setupClassBase(TestBadRecords.class);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientRedirect.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientRedirect.java
@@ -146,8 +146,8 @@ import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.ipc.YarnRPC;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +200,7 @@ public class TestClientRedirect {
     org.apache.hadoop.mapreduce.Counters counters =
         cluster.getJob(jobID).getCounters();
     validateCounters(counters);
-    Assert.assertTrue(amContact);
+    Assertions.assertTrue(amContact);
 
     LOG.info("Sleeping for 5 seconds before stop for" +
     " the client socket to not get EOF immediately..");
@@ -218,7 +218,7 @@ public class TestClientRedirect {
     // Same client
     //results are returned from fake (not started job)
     counters = cluster.getJob(jobID).getCounters();
-    Assert.assertEquals(0, counters.countCounters());
+    Assertions.assertEquals(0, counters.countCounters());
     Job job = cluster.getJob(jobID);
     org.apache.hadoop.mapreduce.TaskID taskId =
       new org.apache.hadoop.mapreduce.TaskID(jobID, TaskType.MAP, 0);
@@ -242,7 +242,7 @@ public class TestClientRedirect {
 
     counters = cluster.getJob(jobID).getCounters();
     validateCounters(counters);
-    Assert.assertTrue(amContact);
+    Assertions.assertTrue(amContact);
 
     // Stop the AM. It is not even restarting. So it should be treated as
     // completed.
@@ -251,7 +251,7 @@ public class TestClientRedirect {
     // Same client
     counters = cluster.getJob(jobID).getCounters();
     validateCounters(counters);
-    Assert.assertTrue(hsContact);
+    Assertions.assertTrue(hsContact);
 
     rmService.stop();
     historyService.stop();
@@ -267,7 +267,7 @@ public class TestClientRedirect {
         LOG.info("Counter is " + itc.next().getDisplayName());
       }
     }
-    Assert.assertEquals(1, counters.countCounters());
+    Assertions.assertEquals(1, counters.countCounters());
   }
 
   class RMService extends AbstractService implements ApplicationClientProtocol {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientServiceDelegate.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClientServiceDelegate.java
@@ -58,8 +58,8 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -94,7 +94,7 @@ public class TestClientServiceDelegate {
         historyServerProxy, getRMDelegate());
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
+    Assertions.assertNotNull(jobStatus);
   }
 
   @Test
@@ -113,9 +113,9 @@ public class TestClientServiceDelegate {
 
     try {
       clientServiceDelegate.getJobStatus(oldJobId);
-      Assert.fail("Invoke should throw exception after retries.");
+      Assertions.fail("Invoke should throw exception after retries.");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      Assertions.assertTrue(e.getMessage().contains(
           "Job ID doesnot Exist"));
     }
   }
@@ -136,7 +136,7 @@ public class TestClientServiceDelegate {
         historyServerProxy, rm);
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
+    Assertions.assertNotNull(jobStatus);
     verify(historyServerProxy, times(3)).getJobReport(
         any(GetJobReportRequest.class));
   }
@@ -175,9 +175,9 @@ public class TestClientServiceDelegate {
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
 
-    Assert.assertNotNull(jobStatus);
+    Assertions.assertNotNull(jobStatus);
     // assert maxClientRetry is not decremented.
-    Assert.assertEquals(conf.getInt(MRJobConfig.MR_CLIENT_MAX_RETRIES,
+    Assertions.assertEquals(conf.getInt(MRJobConfig.MR_CLIENT_MAX_RETRIES,
       MRJobConfig.DEFAULT_MR_CLIENT_MAX_RETRIES), clientServiceDelegate
       .getMaxClientRetry());
     verify(amProxy, times(5)).getJobReport(any(GetJobReportRequest.class));
@@ -213,14 +213,14 @@ public class TestClientServiceDelegate {
 
     try {
       clientServiceDelegate.getJobStatus(oldJobId);
-      Assert.fail("Exception should be thrown upon AuthorizationException");
+      Assertions.fail("Exception should be thrown upon AuthorizationException");
     } catch (IOException e) {
-      Assert.assertEquals(AuthorizationException.class.getName() + ": Denied",
+      Assertions.assertEquals(AuthorizationException.class.getName() + ": Denied",
           e.getMessage());
     }
 
     // assert maxClientRetry is not decremented.
-    Assert.assertEquals(conf.getInt(MRJobConfig.MR_CLIENT_MAX_RETRIES,
+    Assertions.assertEquals(conf.getInt(MRJobConfig.MR_CLIENT_MAX_RETRIES,
       MRJobConfig.DEFAULT_MR_CLIENT_MAX_RETRIES), clientServiceDelegate
       .getMaxClientRetry());
     verify(amProxy, times(1)).getJobReport(any(GetJobReportRequest.class));
@@ -232,8 +232,8 @@ public class TestClientServiceDelegate {
     ClientServiceDelegate clientServiceDelegate = getClientServiceDelegate(
         null, getRMDelegate());
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertEquals("N/A", jobStatus.getUsername());
-    Assert.assertEquals(JobStatus.State.PREP, jobStatus.getState());
+    Assertions.assertEquals("N/A", jobStatus.getUsername());
+    Assertions.assertEquals(JobStatus.State.PREP, jobStatus.getState());
 
     //RM has app report and job History Server is not configured
     ResourceMgrDelegate rm = mock(ResourceMgrDelegate.class);
@@ -243,8 +243,8 @@ public class TestClientServiceDelegate {
 
     clientServiceDelegate = getClientServiceDelegate(null, rm);
     jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertEquals(applicationReport.getUser(), jobStatus.getUsername());
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, jobStatus.getState());
+    Assertions.assertEquals(applicationReport.getUser(), jobStatus.getUsername());
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, jobStatus.getState());
   }
   
   @Test
@@ -259,11 +259,11 @@ public class TestClientServiceDelegate {
         historyServerProxy, rm);
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("TestJobFilePath", jobStatus.getJobFile());                               
-    Assert.assertEquals("http://TestTrackingUrl", jobStatus.getTrackingUrl());                    
-    Assert.assertEquals(1.0f, jobStatus.getMapProgress(), 0.0f);
-    Assert.assertEquals(1.0f, jobStatus.getReduceProgress(), 0.0f);
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("TestJobFilePath", jobStatus.getJobFile());                               
+    Assertions.assertEquals("http://TestTrackingUrl", jobStatus.getTrackingUrl());                    
+    Assertions.assertEquals(1.0f, jobStatus.getMapProgress(), 0.0f);
+    Assertions.assertEquals(1.0f, jobStatus.getReduceProgress(), 0.0f);
   }
   
   @Test
@@ -278,8 +278,8 @@ public class TestClientServiceDelegate {
         historyServerProxy, rm);
 
     Counters counters = TypeConverter.toYarn(clientServiceDelegate.getJobCounters(oldJobId));
-    Assert.assertNotNull(counters);
-    Assert.assertEquals(1001, counters.getCounterGroup("dummyCounters").getCounter("dummyCounter").getValue());                               
+    Assertions.assertNotNull(counters);
+    Assertions.assertEquals(1001, counters.getCounterGroup("dummyCounters").getCounter("dummyCounter").getValue());                               
   }
 
   @Test
@@ -338,16 +338,16 @@ public class TestClientServiceDelegate {
         clientServiceDelegate).instantiateAMProxy(any(InetSocketAddress.class));
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("jobName-firstGen", jobStatus.getJobName());
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("jobName-firstGen", jobStatus.getJobName());
 
     jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("jobName-secondGen", jobStatus.getJobName());
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("jobName-secondGen", jobStatus.getJobName());
 
     jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("jobName-secondGen", jobStatus.getJobName());
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("jobName-secondGen", jobStatus.getJobName());
 
     verify(clientServiceDelegate, times(2)).instantiateAMProxy(
         any(InetSocketAddress.class));
@@ -379,31 +379,31 @@ public class TestClientServiceDelegate {
         historyServerProxy, rmDelegate));
 
     JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("N/A", jobStatus.getJobName());
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("N/A", jobStatus.getJobName());
     
     verify(clientServiceDelegate, times(0)).instantiateAMProxy(
         any(InetSocketAddress.class));
 
     // Should not reach AM even for second and third times too.
     jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("N/A", jobStatus.getJobName());    
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("N/A", jobStatus.getJobName());    
     verify(clientServiceDelegate, times(0)).instantiateAMProxy(
         any(InetSocketAddress.class));
     jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus);
-    Assert.assertEquals("N/A", jobStatus.getJobName());    
+    Assertions.assertNotNull(jobStatus);
+    Assertions.assertEquals("N/A", jobStatus.getJobName());    
     verify(clientServiceDelegate, times(0)).instantiateAMProxy(
         any(InetSocketAddress.class));
 
     // The third time around, app is completed, so should go to JHS
     JobStatus jobStatus1 = clientServiceDelegate.getJobStatus(oldJobId);
-    Assert.assertNotNull(jobStatus1);
-    Assert.assertEquals("TestJobFilePath", jobStatus1.getJobFile());                               
-    Assert.assertEquals("http://TestTrackingUrl", jobStatus1.getTrackingUrl());                    
-    Assert.assertEquals(1.0f, jobStatus1.getMapProgress(), 0.0f);
-    Assert.assertEquals(1.0f, jobStatus1.getReduceProgress(), 0.0f);
+    Assertions.assertNotNull(jobStatus1);
+    Assertions.assertEquals("TestJobFilePath", jobStatus1.getJobFile());                               
+    Assertions.assertEquals("http://TestTrackingUrl", jobStatus1.getTrackingUrl());                    
+    Assertions.assertEquals(1.0f, jobStatus1.getMapProgress(), 0.0f);
+    Assertions.assertEquals(1.0f, jobStatus1.getReduceProgress(), 0.0f);
     
     verify(clientServiceDelegate, times(0)).instantiateAMProxy(
         any(InetSocketAddress.class));
@@ -451,7 +451,7 @@ public class TestClientServiceDelegate {
       JobStatus jobStatus = clientServiceDelegate.getJobStatus(oldJobId);
       verify(rmDelegate, times(3)).getApplicationReport(
           any(ApplicationId.class));
-      Assert.assertNotNull(jobStatus);
+      Assertions.assertNotNull(jobStatus);
     } catch (YarnException e) {
       throw new IOException(e);
     }
@@ -476,7 +476,7 @@ public class TestClientServiceDelegate {
           conf, rmDelegate, oldJobId, historyServerProxy);
       try {
         clientServiceDelegate.getJobStatus(oldJobId);
-        Assert.fail("It should throw exception after retries");
+        Assertions.fail("It should throw exception after retries");
       } catch (IOException e) {
         System.out.println("fail to get job status,and e=" + e.toString());
       }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestClusterMapReduceTestCase.java
@@ -30,16 +30,16 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 public class TestClusterMapReduceTestCase extends ClusterMapReduceTestCase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     setupClassBase(TestClusterMapReduceTestCase.class);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCollect.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCollect.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapred.UtilsForTests.RandomInputFormat;
 import org.apache.hadoop.mapreduce.MRConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.*;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineFileInputFormat.java
@@ -26,11 +26,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.lib.CombineFileInputFormat;
 import org.apache.hadoop.mapred.lib.CombineFileSplit;
 import org.apache.hadoop.mapred.lib.CombineFileRecordReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCombineFileInputFormat {
   private static final Logger LOG =
@@ -79,6 +79,6 @@ public class TestCombineFileInputFormat {
     LOG.info("Trying to getSplits with splits = " + SIZE_SPLITS);
     InputSplit[] splits = format.getSplits(job, SIZE_SPLITS);
     LOG.info("Got getSplits = " + splits.length);
-    assertEquals("splits == " + SIZE_SPLITS, SIZE_SPLITS, splits.length);
+    assertEquals(SIZE_SPLITS, splits.length, "splits == " + SIZE_SPLITS);
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineOutputCollector.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineOutputCollector.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapred.IFile.Writer;
 import org.apache.hadoop.mapred.Task.CombineOutputCollector;
 import org.apache.hadoop.mapred.Task.TaskReporter;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCombineOutputCollector {
   private CombineOutputCollector<String, Integer> coc;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineSequenceFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineSequenceFileInputFormat.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.util.BitSet;
@@ -33,7 +33,8 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.mapred.lib.CombineFileSplit;
 import org.apache.hadoop.mapred.lib.CombineSequenceFileInputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,8 @@ public class TestCombineSequenceFileInputFormat {
       System.getProperty("test.build.data", "/tmp"),
       "TestCombineSequenceFileInputFormat"));
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testFormat() throws Exception {
     JobConf job = new JobConf(conf);
 
@@ -92,10 +94,10 @@ public class TestCombineSequenceFileInputFormat {
 
       // we should have a single split as the length is comfortably smaller than
       // the block size
-      assertEquals("We got more than one splits!", 1, splits.length);
+      assertEquals(1, splits.length, "We got more than one splits!");
       InputSplit split = splits[0];
-      assertEquals("It should be CombineFileSplit",
-        CombineFileSplit.class, split.getClass());
+      assertEquals(
+       CombineFileSplit.class, split.getClass(), "It should be CombineFileSplit");
 
       // check each split
       BitSet bits = new BitSet(length);
@@ -103,13 +105,13 @@ public class TestCombineSequenceFileInputFormat {
         format.getRecordReader(split, job, reporter);
       try {
         while (reader.next(key, value)) {
-          assertFalse("Key in multiple partitions.", bits.get(key.get()));
+          assertFalse(bits.get(key.get()), "Key in multiple partitions.");
           bits.set(key.get());
         }
       } finally {
         reader.close();
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCombineTextInputFormat.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -40,7 +40,8 @@ import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.mapred.lib.CombineFileSplit;
 import org.apache.hadoop.mapred.lib.CombineTextInputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,8 @@ public class TestCombineTextInputFormat {
   // A reporter that does nothing
   private static final Reporter voidReporter = Reporter.NULL;
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testFormat() throws Exception {
     JobConf job = new JobConf(defaultConf);
 
@@ -96,10 +98,10 @@ public class TestCombineTextInputFormat {
 
       // we should have a single split as the length is comfortably smaller than
       // the block size
-      assertEquals("We got more than one splits!", 1, splits.length);
+      assertEquals(1, splits.length, "We got more than one splits!");
       InputSplit split = splits[0];
-      assertEquals("It should be CombineFileSplit",
-        CombineFileSplit.class, split.getClass());
+      assertEquals(
+       CombineFileSplit.class, split.getClass(), "It should be CombineFileSplit");
 
       // check the split
       BitSet bits = new BitSet(length);
@@ -115,7 +117,7 @@ public class TestCombineTextInputFormat {
             LOG.warn("conflict with " + v +
                      " at position "+reader.getPos());
           }
-          assertFalse("Key in multiple partitions.", bits.get(v));
+          assertFalse(bits.get(v), "Key in multiple partitions.");
           bits.set(v);
           count++;
         }
@@ -123,7 +125,7 @@ public class TestCombineTextInputFormat {
       } finally {
         reader.close();
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 
@@ -206,7 +208,8 @@ public class TestCombineTextInputFormat {
   /**
    * Test using the gzip codec for reading
    */
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testGzip() throws IOException {
     JobConf job = new JobConf(defaultConf);
     CompressionCodec gzip = new GzipCodec();
@@ -219,9 +222,9 @@ public class TestCombineTextInputFormat {
     FileInputFormat.setInputPaths(job, workDir);
     CombineTextInputFormat format = new CombineTextInputFormat();
     InputSplit[] splits = format.getSplits(job, 100);
-    assertEquals("compressed splits == 1", 1, splits.length);
+    assertEquals(1, splits.length, "compressed splits == 1");
     List<Text> results = readSplit(format, splits[0], job);
-    assertEquals("splits[0] length", 8, results.size());
+    assertEquals(8, results.size(), "splits[0] length");
 
     final String[] firstList =
       {"the quick", "brown", "fox jumped", "over", " the lazy", " dog"};

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCommandLineJobSubmission.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestCommandLineJobSubmission.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * check for the job submission  options of 
@@ -59,7 +59,7 @@ public class TestCommandLineJobSubmission {
       stream.close();
       mr = new MiniMRCluster(2, fs.getUri().toString(), 1);
       File thisbuildDir = new File(buildDir, "jobCommand");
-      assertTrue("create build dir", thisbuildDir.mkdirs()); 
+      assertTrue(thisbuildDir.mkdirs(), "create build dir"); 
       File f = new File(thisbuildDir, "files_tmp");
       FileOutputStream fstream = new FileOutputStream(f);
       fstream.write("somestrings".getBytes());
@@ -120,13 +120,13 @@ public class TestCommandLineJobSubmission {
       
       JobConf jobConf = mr.createJobConf();
       //before running the job, verify that libjar is not in client classpath
-      assertTrue("libjar not in client classpath", loadLibJar(jobConf)==null);
+      assertTrue(loadLibJar(jobConf)==null, "libjar not in client classpath");
       int ret = ToolRunner.run(jobConf,
                                new testshell.ExternalMapReduce(), args);
       //after running the job, verify that libjar is in the client classpath
-      assertTrue("libjar added to client classpath", loadLibJar(jobConf)!=null);
+      assertTrue(loadLibJar(jobConf)!=null, "libjar added to client classpath");
       
-      assertTrue("not failed ", ret != -1);
+      assertTrue(ret != -1, "not failed ");
       f.delete();
       thisbuildDir.delete();
     } finally {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestComparators.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestComparators.java
@@ -35,11 +35,11 @@ import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.mapreduce.MRConfig;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
@@ -312,7 +312,7 @@ public class TestComparators {
     }
   }
 
-  @Before
+  @BeforeEach
   public void configure() throws Exception {
     Path testdir = new Path(TEST_DIR.getAbsolutePath());
     Path inDir = new Path(testdir, "in");
@@ -355,7 +355,7 @@ public class TestComparators {
     jc = new JobClient(conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_DIR);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFieldSelection.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFieldSelection.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.mapred.lib.*;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.lib.fieldsel.FieldSelectionHelper;
 import org.apache.hadoop.mapreduce.lib.fieldsel.TestMRFieldSelection;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFileInputFormatPathFilter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFileInputFormatPathFilter.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -57,12 +57,12 @@ public class TestFileInputFormatPathFilter {
       new Path(new Path(System.getProperty("test.build.data", "."), "data"),
           "TestFileInputFormatPathFilter");
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     tearDown();
     localFs.mkdirs(workDir);
   }
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (localFs.exists(workDir)) {
       localFs.delete(workDir, true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFileOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestFileOutputFormat.java
@@ -30,8 +30,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestFileOutputFormat extends HadoopTestCase {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestGetSplitHosts.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestGetSplitHosts.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapred;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.net.NetworkTopology;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestGetSplitHosts {
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestIFile.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestIFile.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.io.compress.GzipCodec;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 public class TestIFile {
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestIFileStreams.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestIFileStreams.java
@@ -21,15 +21,15 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestIFileStreams {
   @Test
@@ -75,7 +75,7 @@ public class TestIFileStreams {
       }
       ifis.close();
     } catch (ChecksumException e) {
-      assertEquals("Unexpected bad checksum", DLEN - 1, i);
+      assertEquals(DLEN - 1, i, "Unexpected bad checksum");
       return;
     }
     fail("Did not detect bad data in checksum");
@@ -99,7 +99,7 @@ public class TestIFileStreams {
       }
       ifis.close();
     } catch (ChecksumException e) {
-      assertEquals("Checksum before close", i, DLEN - 8);
+      assertEquals(i, DLEN - 8, "Checksum before close");
       return;
     }
     fail("Did not detect bad data in checksum");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestInputPath.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestInputPath.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestInputPath {
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJavaSerialization.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJavaSerialization.java
@@ -35,9 +35,9 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.serializer.JavaSerializationComparator;
 import org.apache.hadoop.mapreduce.MRConfig;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestJavaSerialization {
 
@@ -58,8 +58,8 @@ public class TestJavaSerialization {
       StringTokenizer st = new StringTokenizer(value.toString());
       while (st.hasMoreTokens()) {
         String token = st.nextToken();
-        assertTrue("Invalid token; expected 'a' or 'b', got " + token,
-          token.equals("a") || token.equals("b"));
+        assertTrue(
+         token.equals("a") || token.equals("b"), "Invalid token; expected 'a' or 'b', got " + token);
         output.collect(token, 1L);
       }
     }
@@ -124,9 +124,9 @@ public class TestJavaSerialization {
 
     String inputFileContents =
         FileUtils.readFileToString(new File(INPUT_FILE.toUri().getPath()));
-    assertTrue("Input file contents not as expected; contents are '"
-        + inputFileContents + "', expected \"b a\n\" ",
-      inputFileContents.equals("b a\n"));
+    assertTrue(
+     inputFileContents.equals("b a\n"), "Input file contents not as expected; contents are '"
+        + inputFileContents + "', expected \"b a\n\" ");
 
     JobClient.runJob(conf);
 
@@ -142,8 +142,8 @@ public class TestJavaSerialization {
       assertEquals("Unexpected output; received output '" + reduceOutput + "'",
           "b\t1", lines[1]);
       assertEquals(
-          "Reduce output has extra lines; output is '" + reduceOutput + "'", 2,
-          lines.length);
+      2
+,           lines.length, "Reduce output has extra lines; output is '" + reduceOutput + "'");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobCleanup.java
@@ -30,13 +30,13 @@ import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.mapreduce.JobCounter;
 import org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A JUnit test to test Map-Reduce job cleanup.
@@ -57,7 +57,7 @@ public class TestJobCleanup {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestJobCleanup.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws IOException {
     JobConf conf = new JobConf();
     fileSys = FileSystem.get(conf);
@@ -82,7 +82,7 @@ public class TestJobCleanup {
     fileSys.mkdirs(emptyInDir);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (fileSys != null) {
       // fileSys.delete(new Path(TEST_ROOT_DIR), true);
@@ -169,14 +169,14 @@ public class TestJobCleanup {
 
     LOG.info("Job finished : " + job.isComplete());
     Path testFile = new Path(outDir, filename);
-    assertTrue("Done file \"" + testFile + "\" missing for job " + id,
-        fileSys.exists(testFile));
+    assertTrue(
+       fileSys.exists(testFile), "Done file \"" + testFile + "\" missing for job " + id);
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for successful job "
-          + id, fileSys.exists(file));
+      assertFalse(fileSys.exists(file), "File " + file + " should not be present for successful job "
+          + id);
     }
   }
 
@@ -196,19 +196,19 @@ public class TestJobCleanup {
     RunningJob job = jobClient.submitJob(jc);
     JobID id = job.getID();
     job.waitForCompletion();
-    assertEquals("Job did not fail", JobStatus.FAILED, job.getJobState());
+    assertEquals(JobStatus.FAILED, job.getJobState(), "Job did not fail");
 
     if (fileName != null) {
       Path testFile = new Path(outDir, fileName);
-      assertTrue("File " + testFile + " missing for failed job " + id,
-          fileSys.exists(testFile));
+      assertTrue(
+         fileSys.exists(testFile), "File " + testFile + " missing for failed job " + id);
     }
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for failed job "
-          + id, fileSys.exists(file));
+      assertFalse(fileSys.exists(file), "File " + file + " should not be present for failed job "
+          + id);
     }
   }
 
@@ -242,19 +242,19 @@ public class TestJobCleanup {
     job.killJob(); // kill the job
 
     job.waitForCompletion(); // wait for the job to complete
-    assertEquals("Job was not killed", JobStatus.KILLED, job.getJobState());
+    assertEquals(JobStatus.KILLED, job.getJobState(), "Job was not killed");
 
     if (fileName != null) {
       Path testFile = new Path(outDir, fileName);
-      assertTrue("File " + testFile + " missing for job " + id,
-          fileSys.exists(testFile));
+      assertTrue(
+         fileSys.exists(testFile), "File " + testFile + " missing for job " + id);
     }
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for killed job "
-          + id, fileSys.exists(file));
+      assertFalse(fileSys.exists(file), "File " + file + " should not be present for killed job "
+          + id);
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobClients.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.mapred;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -40,8 +40,8 @@ import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.TaskReport;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("deprecation")
 public class TestJobClients {
@@ -189,7 +189,7 @@ public class TestJobClients {
     client.displayJobList(new JobStatus[] {mockJobStatus}, new PrintWriter(out));
     String commandLineOutput = out.toString();
     System.out.println(commandLineOutput);
-    Assert.assertTrue(commandLineOutput.contains("Total jobs:1"));
+    Assertions.assertTrue(commandLineOutput.contains("Total jobs:1"));
 
     verify(mockJobStatus, atLeastOnce()).getJobID();
     verify(mockJobStatus).getState();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobCounters.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobCounters.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,9 +46,9 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormatCounter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormatCounter;
 import org.apache.hadoop.yarn.util.ResourceCalculatorProcessTree;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This is an wordcount application that tests the count of records
@@ -179,7 +179,7 @@ public class TestJobCounters {
     return len;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void initPaths() throws IOException {
     final Configuration conf = new Configuration();
     final Path TEST_ROOT_DIR =
@@ -207,7 +207,7 @@ public class TestJobCounters {
     createWordsFile(inFiles[2], conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     //clean up the input and output files
     final Configuration conf = new Configuration();
@@ -528,7 +528,7 @@ public class TestJobCounters {
                     OutputCollector<WritableComparable, Writable> output,
                     Reporter reporter)
     throws IOException {
-      assertNotNull("Mapper not configured!", loader);
+      assertNotNull(loader, "Mapper not configured!");
       
       // load the memory
       loader.load();
@@ -557,7 +557,7 @@ public class TestJobCounters {
                        OutputCollector<WritableComparable, Writable> output,
                        Reporter reporter)
     throws IOException {
-      assertNotNull("Reducer not configured!", loader);
+      assertNotNull(loader, "Reducer not configured!");
       
       // load the memory
       loader.load();
@@ -582,10 +582,10 @@ public class TestJobCounters {
       reports = client.getReduceTaskReports(id);
     }
     
-    assertNotNull("No reports found for task type '" + type.name() 
-                  + "' in job " + id, reports);
+    assertNotNull(reports, "No reports found for task type '" + type.name() 
+                  + "' in job " + id);
     // make sure that the total number of reports match the expected
-    assertEquals("Mismatch in task id", numReports, reports.length);
+    assertEquals(numReports, reports.length, "Mismatch in task id");
     
     Counters counters = reports[taskId].getCounters();
     
@@ -632,7 +632,7 @@ public class TestJobCounters {
     RunningJob job = client.submitJob(jobConf);
     job.waitForCompletion();
     JobID jobID = job.getID();
-    assertTrue("Job " + jobID + " failed!", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job " + jobID + " failed!");
     
     return job;
   }
@@ -708,11 +708,11 @@ public class TestJobCounters {
       System.out.println("Job2 (high memory job) reduce task heap usage: " 
                          + highMemJobReduceHeapUsage);
 
-      assertTrue("Incorrect map heap usage reported by the map task", 
-                 lowMemJobMapHeapUsage < highMemJobMapHeapUsage);
+      assertTrue(
+                 lowMemJobMapHeapUsage < highMemJobMapHeapUsage, "Incorrect map heap usage reported by the map task");
 
-      assertTrue("Incorrect reduce heap usage reported by the reduce task", 
-                 lowMemJobReduceHeapUsage < highMemJobReduceHeapUsage);
+      assertTrue(
+                 lowMemJobReduceHeapUsage < highMemJobReduceHeapUsage, "Incorrect reduce heap usage reported by the reduce task");
     } finally {
       // shutdown the mr cluster
       mrCluster.shutdown();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobName.java
@@ -30,14 +30,14 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestJobName extends ClusterMapReduceTestCase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     setupClassBase(TestJobName.class);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobSysDirWithDFS.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestJobSysDirWithDFS.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestKeyValueTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestKeyValueTextInputFormat.java
@@ -26,13 +26,13 @@ import org.apache.hadoop.io.*;
 import org.apache.hadoop.io.compress.*;
 import org.apache.hadoop.util.LineReader;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestKeyValueTextInputFormat {
   private static final Logger LOG =
@@ -102,14 +102,14 @@ public class TestKeyValueTextInputFormat {
           RecordReader<Text, Text> reader =
             format.getRecordReader(splits[j], job, reporter);
           Class readerClass = reader.getClass();
-          assertEquals("reader class is KeyValueLineRecordReader.", KeyValueLineRecordReader.class, readerClass);        
+          assertEquals(KeyValueLineRecordReader.class, readerClass, "reader class is KeyValueLineRecordReader.");        
 
           Text key = reader.createKey();
           Class keyClass = key.getClass();
           Text value = reader.createValue();
           Class valueClass = value.getClass();
-          assertEquals("Key class is Text.", Text.class, keyClass);
-          assertEquals("Value class is Text.", Text.class, valueClass);
+          assertEquals(Text.class, keyClass, "Key class is Text.");
+          assertEquals(Text.class, valueClass, "Value class is Text.");
           try {
             int count = 0;
             while (reader.next(key, value)) {
@@ -120,7 +120,7 @@ public class TestKeyValueTextInputFormat {
                          " in split " + j +
                          " at position "+reader.getPos());
               }
-              assertFalse("Key in multiple partitions.", bits.get(v));
+              assertFalse(bits.get(v), "Key in multiple partitions.");
               bits.set(v);
               count++;
             }
@@ -129,7 +129,7 @@ public class TestKeyValueTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }
@@ -163,18 +163,18 @@ public class TestKeyValueTextInputFormat {
       in = makeStream("a\nbb\n\nccc\rdddd\r\neeeee");
       Text out = new Text();
       in.readLine(out);
-      assertEquals("line1 length", 1, out.getLength());
+      assertEquals(1, out.getLength(), "line1 length");
       in.readLine(out);
-      assertEquals("line2 length", 2, out.getLength());
+      assertEquals(2, out.getLength(), "line2 length");
       in.readLine(out);
-      assertEquals("line3 length", 0, out.getLength());
+      assertEquals(0, out.getLength(), "line3 length");
       in.readLine(out);
-      assertEquals("line4 length", 3, out.getLength());
+      assertEquals(3, out.getLength(), "line4 length");
       in.readLine(out);
-      assertEquals("line5 length", 4, out.getLength());
+      assertEquals(4, out.getLength(), "line5 length");
       in.readLine(out);
-      assertEquals("line5 length", 5, out.getLength());
-      assertEquals("end of file", 0, in.readLine(out));
+      assertEquals(5, out.getLength(), "line5 length");
+      assertEquals(0, in.readLine(out), "end of file");
     } finally {
       if (in != null) {
         in.close();
@@ -236,17 +236,17 @@ public class TestKeyValueTextInputFormat {
     KeyValueTextInputFormat format = new KeyValueTextInputFormat();
     format.configure(job);
     InputSplit[] splits = format.getSplits(job, 100);
-    assertEquals("compressed splits == 2", 2, splits.length);
+    assertEquals(2, splits.length, "compressed splits == 2");
     FileSplit tmp = (FileSplit) splits[0];
     if (tmp.getPath().getName().equals("part2.txt.gz")) {
       splits[0] = splits[1];
       splits[1] = tmp;
     }
     List<Text> results = readSplit(format, splits[0], job);
-    assertEquals("splits[0] length", 6, results.size());
+    assertEquals(6, results.size(), "splits[0] length");
     assertEquals("splits[0][5]", " dog", results.get(5).toString());
     results = readSplit(format, splits[1], job);
-    assertEquals("splits[1] length", 2, results.size());
+    assertEquals(2, results.size(), "splits[1] length");
     assertEquals("splits[1][0]", "this is a test", 
                  results.get(0).toString());    
     assertEquals("splits[1][1]", "of gzip", 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLazyOutput.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLazyOutput.java
@@ -33,8 +33,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.LazyOutputFormat;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A JUnit test to test the Map-Reduce framework's feature to create part

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLineRecordReaderJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLineRecordReaderJobs.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLineRecordReaderJobs {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLocalJobSubmission.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestLocalJobSubmission.java
@@ -37,16 +37,16 @@ import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * check for the job submission options of
@@ -64,14 +64,14 @@ public class TestLocalJobSubmission {
   private Path jarPath;
   private Configuration config;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     // setup the test root directory
     testRootDir =
         GenericTestUtils.setupTestRootDir(TestLocalJobSubmission.class);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     unitTestDir = new File(testRootDir, unitTestName.getMethodName());
     unitTestDir.mkdirs();
@@ -120,7 +120,7 @@ public class TestLocalJobSubmission {
       LOG.error("Job failed with {}", e.getLocalizedMessage(), e);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 
   /**
@@ -140,13 +140,13 @@ public class TestLocalJobSubmission {
           (SpillCallBackPathsFinder) IntermediateEncryptedStream
               .setSpillCBInjector(new SpillCallBackPathsFinder());
       res = ToolRunner.run(config, new SleepJob(), args);
-      Assert.assertTrue("No spill occurred",
-          spillInjector.getEncryptedSpilledFiles().size() > 0);
+      Assertions.assertTrue(
+         spillInjector.getEncryptedSpilledFiles().size() > 0, "No spill occurred");
     } catch (Exception e) {
       LOG.error("Job failed with {}", e.getLocalizedMessage(), e);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 
   /**
@@ -188,7 +188,7 @@ public class TestLocalJobSubmission {
       LOG.error("Job failed with {}", e.getLocalizedMessage(), e);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 
   /**
@@ -209,7 +209,7 @@ public class TestLocalJobSubmission {
       LOG.error("Job failed with {}" + e.getLocalizedMessage(), e);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 
   private Path makeJar(Path p) throws IOException {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileInputFormat.java
@@ -26,16 +26,16 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DFSTestUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.Text;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,8 +94,8 @@ public class TestMRCJCFileInputFormat {
                   blockLocs[0].equals(splitLocs[1])));
     }
 
-    assertEquals("Expected value of " + FileInputFormat.NUM_INPUT_FILES,
-                 1, job.getLong(FileInputFormat.NUM_INPUT_FILES, 0));
+    assertEquals(
+                1, job.getLong(FileInputFormat.NUM_INPUT_FILES, 0), "Expected value of " + FileInputFormat.NUM_INPUT_FILES);
   }
 
   private void createInputs(FileSystem fs, Path inDir, String fileName)
@@ -135,8 +135,8 @@ public class TestMRCJCFileInputFormat {
     inFormat.configure(job);
     InputSplit[] splits = inFormat.getSplits(job, 1);
 
-    assertEquals("Expected value of " + FileInputFormat.NUM_INPUT_FILES,
-                 numFiles, job.getLong(FileInputFormat.NUM_INPUT_FILES, 0));
+    assertEquals(
+                numFiles, job.getLong(FileInputFormat.NUM_INPUT_FILES, 0), "Expected value of " + FileInputFormat.NUM_INPUT_FILES);
   }
   
   final Path root = new Path("/TestFileInputFormat");
@@ -191,8 +191,8 @@ public class TestMRCJCFileInputFormat {
     } catch (Exception e) {
       exceptionThrown = true;
     }
-    assertTrue("Exception should be thrown by default for scanning a "
-        + "directory with directories inside.", exceptionThrown);
+    assertTrue(exceptionThrown, "Exception should be thrown by default for scanning a "
+        + "directory with directories inside.");
 
     // Enable multi-level/recursive inputs
     job.setBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, true);
@@ -314,7 +314,7 @@ public class TestMRCJCFileInputFormat {
     DFSTestUtil.waitReplication(fileSys, name, replication);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (dfs != null) {
       dfs.shutdown();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCFileOutputCommitter.java
@@ -26,18 +26,18 @@ import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMRCJCFileOutputCommitter {
   private static Path outDir = new Path(GenericTestUtils.getTempPath("output"));
@@ -145,14 +145,14 @@ public class TestMRCJCFileOutputCommitter {
     committer.abortTask(tContext);
     File expectedFile = new File(new Path(committer
         .getTaskAttemptPath(tContext), file).toString());
-    assertFalse("task temp dir still exists", expectedFile.exists());
+    assertFalse(expectedFile.exists(), "task temp dir still exists");
 
     committer.abortJob(jContext, JobStatus.State.FAILED);
     expectedFile = new File(new Path(outDir, FileOutputCommitter.TEMP_DIR_NAME)
         .toString());
-    assertFalse("job temp dir "+expectedFile+" still exists", expectedFile.exists());
-    assertEquals("Output directory not empty", 0, new File(outDir.toString())
-        .listFiles().length);
+    assertFalse(expectedFile.exists(), "job temp dir "+expectedFile+" still exists");
+    assertEquals(0, new File(outDir.toString())
+        .listFiles().length, "Output directory not empty");
   }
 
   public static class FakeFileSystem extends RawLocalFileSystem {
@@ -210,7 +210,7 @@ public class TestMRCJCFileOutputCommitter {
     assertNotNull(th);
     assertTrue(th instanceof IOException);
     assertTrue(th.getMessage().contains("fake delete failed"));
-    assertTrue(expectedFile + " does not exists", expectedFile.exists());
+    assertTrue(expectedFile.exists(), expectedFile + " does not exists");
 
     th = null;
     try {
@@ -221,10 +221,10 @@ public class TestMRCJCFileOutputCommitter {
     assertNotNull(th);
     assertTrue(th instanceof IOException);
     assertTrue(th.getMessage().contains("fake delete failed"));
-    assertTrue("job temp dir does not exists", jobTmpDir.exists());
+    assertTrue(jobTmpDir.exists(), "job temp dir does not exists");
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     FileUtil.fullyDelete(new File(outDir.toString()));
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobClient.java
@@ -30,12 +30,12 @@ import org.apache.hadoop.mapreduce.TestMRJobClient;
 import org.apache.hadoop.mapreduce.tools.CLI;
 import org.apache.hadoop.util.Tool;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Ignore;
 @Ignore
 public class TestMRCJCJobClient extends TestMRJobClient {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     setupClassBase(TestMRCJCJobClient.class);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRCJCJobConf.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.mapred;
 
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.net.URLClassLoader;
 import java.net.URL;
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.util.ClassUtil;
 
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 @Ignore
 public class TestMRCJCJobConf {
   private static final String JAR_RELATIVE_PATH =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMROpportunisticMaps.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMROpportunisticMaps.java
@@ -28,14 +28,14 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.util.MRJobConfUtil;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple MapReduce to test ability of the MRAppMaster to request and use

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRTimelineEventHandling.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMRTimelineEventHandling.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -56,8 +56,8 @@ import org.apache.hadoop.yarn.server.timelineservice.storage.FileSystemTimelineR
 import org.apache.hadoop.yarn.server.timelineservice.storage.FileSystemTimelineWriterImpl;
 import org.apache.hadoop.yarn.server.timelineservice.storage.TimelineWriter;
 import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,8 +85,8 @@ public class TestMRTimelineEventHandling {
       cluster.start();
 
       //verify that the timeline service is not started.
-      Assert.assertNull("Timeline Service should not have been started",
-          cluster.getApplicationHistoryServer());
+      Assertions.assertNull(
+         cluster.getApplicationHistoryServer(), "Timeline Service should not have been started");
     }
     finally {
       if(cluster != null) {
@@ -103,8 +103,8 @@ public class TestMRTimelineEventHandling {
       cluster.start();
 
       //verify that the timeline service is not started.
-      Assert.assertNull("Timeline Service should not have been started",
-          cluster.getApplicationHistoryServer());
+      Assertions.assertNull(
+         cluster.getApplicationHistoryServer(), "Timeline Service should not have been started");
     }
     finally {
       if(cluster != null) {
@@ -135,33 +135,33 @@ public class TestMRTimelineEventHandling {
       Path outDir = new Path(localPathRoot, "output");
       RunningJob job =
               UtilsForTests.runJobSucceed(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
               job.getJobStatus().getState().getValue());
       TimelineEntities entities = ts.getEntities("MAPREDUCE_JOB", null, null,
               null, null, null, null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       TimelineEntity tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(job.getID().toString(), tEntity.getEntityId());
-      Assert.assertEquals("MAPREDUCE_JOB", tEntity.getEntityType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(job.getID().toString(), tEntity.getEntityId());
+      Assertions.assertEquals("MAPREDUCE_JOB", tEntity.getEntityType());
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(tEntity.getEvents().size() - 1)
               .getEventType());
-      Assert.assertEquals(EventType.JOB_FINISHED.toString(),
+      Assertions.assertEquals(EventType.JOB_FINISHED.toString(),
               tEntity.getEvents().get(0).getEventType());
 
       job = UtilsForTests.runJobFail(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.FAILED,
+      Assertions.assertEquals(JobStatus.FAILED,
               job.getJobStatus().getState().getValue());
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null, null, null,
               null, null, null, null);
-      Assert.assertEquals(2, entities.getEntities().size());
+      Assertions.assertEquals(2, entities.getEntities().size());
       tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(job.getID().toString(), tEntity.getEntityId());
-      Assert.assertEquals("MAPREDUCE_JOB", tEntity.getEntityType());
-      Assert.assertEquals(EventType.AM_STARTED.toString(),
+      Assertions.assertEquals(job.getID().toString(), tEntity.getEntityId());
+      Assertions.assertEquals("MAPREDUCE_JOB", tEntity.getEntityType());
+      Assertions.assertEquals(EventType.AM_STARTED.toString(),
               tEntity.getEvents().get(tEntity.getEvents().size() - 1)
               .getEventType());
-      Assert.assertEquals(EventType.JOB_FAILED.toString(),
+      Assertions.assertEquals(EventType.JOB_FAILED.toString(),
               tEntity.getEvents().get(0).getEventType());
     } finally {
       if (cluster != null) {
@@ -221,7 +221,7 @@ public class TestMRTimelineEventHandling {
           UtilsForTests.createConfigValue(101 * 1024));
       RunningJob job =
           UtilsForTests.runJobSucceed(successConf, inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
           job.getJobStatus().getState().getValue());
 
       YarnClient yarnClient = YarnClient.createYarnClient();
@@ -232,7 +232,7 @@ public class TestMRTimelineEventHandling {
 
       ApplicationId firstAppId = null;
       List<ApplicationReport> apps = yarnClient.getApplications(appStates);
-      Assert.assertEquals(apps.size(), 1);
+      Assertions.assertEquals(apps.size(), 1);
       ApplicationReport appReport = apps.get(0);
       firstAppId = appReport.getApplicationId();
       UtilsForTests.waitForAppFinished(job, cluster);
@@ -240,11 +240,11 @@ public class TestMRTimelineEventHandling {
 
       LOG.info("Run 2nd job which should be failed.");
       job = UtilsForTests.runJobFail(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.FAILED,
+      Assertions.assertEquals(JobStatus.FAILED,
           job.getJobStatus().getState().getValue());
 
       apps = yarnClient.getApplications(appStates);
-      Assert.assertEquals(apps.size(), 2);
+      Assertions.assertEquals(apps.size(), 2);
 
       appReport = apps.get(0).getApplicationId().equals(firstAppId) ?
           apps.get(0) : apps.get(1);
@@ -270,7 +270,7 @@ public class TestMRTimelineEventHandling {
 
     File tmpRootFolder = new File(tmpRoot);
 
-    Assert.assertTrue(tmpRootFolder.isDirectory());
+    Assertions.assertTrue(tmpRootFolder.isDirectory());
     String basePath = tmpRoot + YarnConfiguration.DEFAULT_RM_CLUSTER_ID +
         File.separator +
         UserGroupInformation.getCurrentUser().getShortUserName() +
@@ -283,9 +283,9 @@ public class TestMRTimelineEventHandling {
         basePath + File.separator + "MAPREDUCE_JOB" + File.separator;
 
     File entityFolder = new File(outputDirJob);
-    Assert.assertTrue("Job output directory: " + outputDirJob +
-        " does not exist.",
-        entityFolder.isDirectory());
+    Assertions.assertTrue(
+       entityFolder.isDirectory(), "Job output directory: " + outputDirJob +
+        " does not exist.");
 
     // check for job event file
     String jobEventFileName = appId.toString().replaceAll("application", "job")
@@ -293,9 +293,9 @@ public class TestMRTimelineEventHandling {
 
     String jobEventFilePath = outputDirJob + jobEventFileName;
     File jobEventFile = new File(jobEventFilePath);
-    Assert.assertTrue("jobEventFilePath: " + jobEventFilePath +
-        " does not exist.",
-        jobEventFile.exists());
+    Assertions.assertTrue(
+       jobEventFile.exists(), "jobEventFilePath: " + jobEventFilePath +
+        " does not exist.");
     verifyEntity(jobEventFile, EventType.JOB_FINISHED.name(),
         true, false, null, false);
     Set<String> cfgsToCheck = Sets.newHashSet("dummy_conf1", "dummy_conf2",
@@ -306,10 +306,10 @@ public class TestMRTimelineEventHandling {
     String outputAppDir =
         basePath + File.separator + "YARN_APPLICATION" + File.separator;
     entityFolder = new File(outputAppDir);
-    Assert.assertTrue(
-        "Job output directory: " + outputAppDir +
-        " does not exist.",
-        entityFolder.isDirectory());
+    Assertions.assertTrue(
+    
+       entityFolder.isDirectory(), "Job output directory: " + outputAppDir +
+        " does not exist.");
 
     // check for job event file
     String appEventFileName = appId.toString()
@@ -317,10 +317,10 @@ public class TestMRTimelineEventHandling {
 
     String appEventFilePath = outputAppDir + appEventFileName;
     File appEventFile = new File(appEventFilePath);
-    Assert.assertTrue(
-        "appEventFilePath: " + appEventFilePath +
-        " does not exist.",
-        appEventFile.exists());
+    Assertions.assertTrue(
+    
+       appEventFile.exists(), "appEventFilePath: " + appEventFilePath +
+        " does not exist.");
     verifyEntity(appEventFile, null, true, false, null, false);
     verifyEntity(appEventFile, null, false, true, cfgsToCheck, false);
 
@@ -328,9 +328,9 @@ public class TestMRTimelineEventHandling {
     String outputDirTask =
         basePath + File.separator + "MAPREDUCE_TASK" + File.separator;
     File taskFolder = new File(outputDirTask);
-    Assert.assertTrue("Task output directory: " + outputDirTask +
-        " does not exist.",
-        taskFolder.isDirectory());
+    Assertions.assertTrue(
+       taskFolder.isDirectory(), "Task output directory: " + outputDirTask +
+        " does not exist.");
 
     String taskEventFileName =
         appId.toString().replaceAll("application", "task") +
@@ -339,9 +339,9 @@ public class TestMRTimelineEventHandling {
 
     String taskEventFilePath = outputDirTask + taskEventFileName;
     File taskEventFile = new File(taskEventFilePath);
-    Assert.assertTrue("taskEventFileName: " + taskEventFilePath +
-        " does not exist.",
-        taskEventFile.exists());
+    Assertions.assertTrue(
+       taskEventFile.exists(), "taskEventFileName: " + taskEventFilePath +
+        " does not exist.");
     verifyEntity(taskEventFile, EventType.TASK_FINISHED.name(),
         true, false, null, true);
 
@@ -349,8 +349,8 @@ public class TestMRTimelineEventHandling {
     String outputDirTaskAttempt =
         basePath + File.separator + "MAPREDUCE_TASK_ATTEMPT" + File.separator;
     File taskAttemptFolder = new File(outputDirTaskAttempt);
-    Assert.assertTrue("TaskAttempt output directory: " + outputDirTaskAttempt +
-        " does not exist.", taskAttemptFolder.isDirectory());
+    Assertions.assertTrue(taskAttemptFolder.isDirectory(), "TaskAttempt output directory: " + outputDirTaskAttempt +
+        " does not exist.");
 
     String taskAttemptEventFileName = appId.toString().replaceAll(
         "application", "attempt") + "_m_000000_0" +
@@ -359,8 +359,8 @@ public class TestMRTimelineEventHandling {
     String taskAttemptEventFilePath = outputDirTaskAttempt +
         taskAttemptEventFileName;
     File taskAttemptEventFile = new File(taskAttemptEventFilePath);
-    Assert.assertTrue("taskAttemptEventFileName: " + taskAttemptEventFilePath +
-        " does not exist.", taskAttemptEventFile.exists());
+    Assertions.assertTrue(taskAttemptEventFile.exists(), "taskAttemptEventFileName: " + taskAttemptEventFilePath +
+        " does not exist.");
     verifyEntity(taskAttemptEventFile, EventType.MAP_ATTEMPT_FINISHED.name(),
         true, false, null, true);
   }
@@ -397,14 +397,14 @@ public class TestMRTimelineEventHandling {
 
           LOG.info("strLine.trim()= " + strLine.trim());
           if (checkIdPrefix) {
-            Assert.assertTrue("Entity ID prefix expected to be > 0",
-                entity.getIdPrefix() > 0);
+            Assertions.assertTrue(
+               entity.getIdPrefix() > 0, "Entity ID prefix expected to be > 0");
             if (idPrefix == -1) {
               idPrefix = entity.getIdPrefix();
             } else {
-              Assert.assertEquals("Entity ID prefix should be same across " +
-                  "each publish of same entity",
-                      idPrefix, entity.getIdPrefix());
+              Assertions.assertEquals(
+                     idPrefix, entity.getIdPrefix(), "Entity ID prefix should be same across " +
+                  "each publish of same entity");
             }
           }
           if (eventId == null) {
@@ -492,21 +492,21 @@ public class TestMRTimelineEventHandling {
 
       RunningJob job =
           UtilsForTests.runJobSucceed(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
           job.getJobStatus().getState().getValue());
       TimelineEntities entities = ts.getEntities("MAPREDUCE_JOB", null, null,
           null, null, null, null, null, null, null);
-      Assert.assertEquals(0, entities.getEntities().size());
+      Assertions.assertEquals(0, entities.getEntities().size());
 
       conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_EMIT_TIMELINE_DATA, true);
       job = UtilsForTests.runJobSucceed(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
           job.getJobStatus().getState().getValue());
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null, null, null,
           null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       TimelineEntity tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(job.getID().toString(), tEntity.getEntityId());
+      Assertions.assertEquals(job.getID().toString(), tEntity.getEntityId());
     } finally {
       if (cluster != null) {
         cluster.stop();
@@ -532,21 +532,21 @@ public class TestMRTimelineEventHandling {
       conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_EMIT_TIMELINE_DATA, false);
       RunningJob job =
           UtilsForTests.runJobSucceed(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
           job.getJobStatus().getState().getValue());
       TimelineEntities entities = ts.getEntities("MAPREDUCE_JOB", null, null,
           null, null, null, null, null, null, null);
-      Assert.assertEquals(0, entities.getEntities().size());
+      Assertions.assertEquals(0, entities.getEntities().size());
 
       conf.setBoolean(MRJobConfig.MAPREDUCE_JOB_EMIT_TIMELINE_DATA, true);
       job = UtilsForTests.runJobSucceed(new JobConf(conf), inDir, outDir);
-      Assert.assertEquals(JobStatus.SUCCEEDED,
+      Assertions.assertEquals(JobStatus.SUCCEEDED,
           job.getJobStatus().getState().getValue());
       entities = ts.getEntities("MAPREDUCE_JOB", null, null, null, null, null,
           null, null, null, null);
-      Assert.assertEquals(1, entities.getEntities().size());
+      Assertions.assertEquals(1, entities.getEntities().size());
       TimelineEntity tEntity = entities.getEntities().get(0);
-      Assert.assertEquals(job.getID().toString(), tEntity.getEntityId());
+      Assertions.assertEquals(job.getID().toString(), tEntity.getEntityId());
     } finally {
       if (cluster != null) {
         cluster.stop();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapOutputType.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapOutputType.java
@@ -31,11 +31,11 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.MRConfig;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /** 
@@ -90,7 +90,7 @@ public class TestMapOutputType {
     }
   }
 
-  @Before
+  @BeforeEach
   public void configure() throws Exception {
     Path testdir = new Path(TEST_DIR.getAbsolutePath());
     Path inDir = new Path(testdir, "in");
@@ -124,7 +124,7 @@ public class TestMapOutputType {
     jc = new JobClient(conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_DIR);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapProgress.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapProgress.java
@@ -36,11 +36,11 @@ import org.apache.hadoop.mapreduce.split.JobSplit.TaskSplitMetaInfo;
 import org.apache.hadoop.mapreduce.split.JobSplitWriter;
 import org.apache.hadoop.mapreduce.split.SplitMetaInfoReader;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *  Validates map phase progress.
@@ -193,8 +193,8 @@ public class TestMapProgress {
         return;
       }
       // validate map task progress when the map task is in map phase
-      assertTrue("Map progress is not the expected value.",
-                 Math.abs(mapTaskProgress - ((float)recordNum/3)) < 0.001);
+      assertTrue(
+                Math.abs(mapTaskProgress - ((float)recordNum/3)) < 0.001, "Map progress is not the expected value.");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapRed.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMapRed.java
@@ -48,11 +48,11 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**********************************************************
  * MapredLoadTest generates a bunch of work that exercises
@@ -254,7 +254,7 @@ public class TestMapRed extends Configured implements Tool {
   private static int counts = 100;
   private static Random r = new Random();
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_DIR);
   }
@@ -309,12 +309,12 @@ public class TestMapRed extends Configured implements Tool {
         mapOutputFile.setConf(conf);
         Path input = mapOutputFile.getInputFile(0);
         FileSystem fs = FileSystem.get(conf);
-        assertTrue("reduce input exists " + input, fs.exists(input));
+        assertTrue(fs.exists(input), "reduce input exists " + input);
         SequenceFile.Reader rdr = 
           new SequenceFile.Reader(fs, input, conf);
-        assertEquals("is reduce input compressed " + input, 
+        assertEquals(
                      compressInput, 
-                     rdr.isCompressed());
+                     rdr.isCompressed(), "is reduce input compressed " + input);
         rdr.close();          
       }
     }
@@ -372,10 +372,10 @@ public class TestMapRed extends Configured implements Tool {
         new Path(testdir, "nullout/part-00000"), conf);
     m = "AAAAAAAAAAAAAA";
     for (int i = 1; r.next(NullWritable.get(), t); ++i) {
-      assertTrue("Unexpected value: " + t, values.remove(t.toString()));
+      assertTrue(values.remove(t.toString()), "Unexpected value: " + t);
       m = m.replace((char)('A' + i - 1), (char)('A' + i));
     }
-    assertTrue("Missing values: " + values.toString(), values.isEmpty());
+    assertTrue(values.isEmpty(), "Missing values: " + values.toString());
   }
 
   private void checkCompression(boolean compressMapOutputs,
@@ -415,16 +415,16 @@ public class TestMapRed extends Configured implements Tool {
       f.writeBytes("Is this done, yet?\n");
       f.close();
       RunningJob rj = JobClient.runJob(conf);
-      assertTrue("job was complete", rj.isComplete());
-      assertTrue("job was successful", rj.isSuccessful());
+      assertTrue(rj.isComplete(), "job was complete");
+      assertTrue(rj.isSuccessful(), "job was successful");
       Path output = new Path(outDir,
                              Task.getOutputName(0));
-      assertTrue("reduce output exists " + output, fs.exists(output));
+      assertTrue(fs.exists(output), "reduce output exists " + output);
       SequenceFile.Reader rdr = 
         new SequenceFile.Reader(fs, output, conf);
-      assertEquals("is reduce output compressed " + output, 
+      assertEquals(
                    redCompression != CompressionType.NONE, 
-                   rdr.isCompressed());
+                   rdr.isCompressed(), "is reduce output compressed " + output);
       rdr.close();
     } finally {
       fs.delete(testdir, true);
@@ -663,7 +663,7 @@ public class TestMapRed extends Configured implements Tool {
     } finally {
       bw.close();
     }
-    assertTrue("testMapRed failed", success);
+    assertTrue(success, "testMapRed failed");
     fs.delete(testdir, true);
   }
 
@@ -778,7 +778,7 @@ public class TestMapRed extends Configured implements Tool {
 
       JobClient.runJob(conf);
     } catch (Exception e) {
-      assertTrue("Threw exception:" + e,false);
+      assertTrue(false, "Threw exception:" + e);
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMerge.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMerge.java
@@ -44,8 +44,8 @@ import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.io.serializer.Serializer;
 
 import org.apache.hadoop.mapred.Task.TaskReporter;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings(value={"unchecked", "deprecation"})
 /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRBringup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRBringup.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapred;
 
 import java.io.IOException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
@@ -50,7 +50,7 @@ public class TestMiniMRBringup {
       mr = new MiniMRYarnCluster("testMiniMRYarnClusterWithoutJHS");
       mr.init(conf);
       mr.start();
-      Assert.assertEquals(null, mr.getHistoryServer());
+      Assertions.assertEquals(null, mr.getHistoryServer());
     } finally {
       if (mr != null) {
         mr.stop();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRChildTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRChildTask.java
@@ -18,10 +18,10 @@
 package org.apache.hadoop.mapred;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -42,9 +42,9 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
 import org.apache.hadoop.util.Shell;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -170,19 +170,19 @@ public class TestMiniMRChildTask {
       boolean oldConfigs = job.getBoolean(OLD_CONFIGS, false);
       if (oldConfigs) {
         String javaOpts = job.get(JobConf.MAPRED_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_TASK_JAVA_OPTS + " is null!", 
-                      javaOpts);
+        assertNotNull(
+                      javaOpts, JobConf.MAPRED_TASK_JAVA_OPTS + " is null!");
         assertThat(javaOpts)
             .withFailMessage(JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: "
                 + javaOpts)
             .isEqualTo(TASK_OPTS_VAL);
       } else {
         String mapJavaOpts = job.get(JobConf.MAPRED_MAP_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " is null!", 
-                      mapJavaOpts);
-        assertEquals(JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " has value of: " + 
-                     mapJavaOpts, 
-                     mapJavaOpts, MAP_OPTS_VAL);
+        assertNotNull(
+                      mapJavaOpts, JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " is null!");
+        assertEquals(
+                     mapJavaOpts, MAP_OPTS_VAL, JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " has value of: " + 
+                     mapJavaOpts);
       }
 
       // check if X=y works for an already existing parameter
@@ -193,8 +193,8 @@ public class TestMiniMRChildTask {
       checkEnv("NEW_PATH", File.pathSeparator + "/tmp", "noappend");
 
       String jobLocalDir = job.get(MRJobConfig.JOB_LOCAL_DIR);
-      assertNotNull(MRJobConfig.JOB_LOCAL_DIR + " is null",
-                    jobLocalDir);
+      assertNotNull(
+                   jobLocalDir, MRJobConfig.JOB_LOCAL_DIR + " is null");
     }
 
     public void map(WritableComparable key, Writable value,
@@ -214,16 +214,16 @@ public class TestMiniMRChildTask {
       boolean oldConfigs = job.getBoolean(OLD_CONFIGS, false);
       if (oldConfigs) {
         String javaOpts = job.get(JobConf.MAPRED_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_TASK_JAVA_OPTS + " is null!", 
-                      javaOpts);
+        assertNotNull(
+                      javaOpts, JobConf.MAPRED_TASK_JAVA_OPTS + " is null!");
         assertThat(javaOpts)
             .withFailMessage(JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: "
                 + javaOpts)
             .isEqualTo(TASK_OPTS_VAL);
       } else {
         String reduceJavaOpts = job.get(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " is null!", 
-                      reduceJavaOpts);
+        assertNotNull(
+                      reduceJavaOpts, JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " is null!");
         assertThat(reduceJavaOpts)
             .withFailMessage(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS +
                 " has value of: " + reduceJavaOpts)
@@ -247,7 +247,7 @@ public class TestMiniMRChildTask {
     
   }
   
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     // create configuration, dfs, file system and mapred cluster 
     dfs = new MiniDFSCluster.Builder(conf).build();
@@ -272,7 +272,7 @@ public class TestMiniMRChildTask {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     // close file system and shut down dfs and mapred cluster
     try {
@@ -378,7 +378,7 @@ public class TestMiniMRChildTask {
     job.setMaxMapAttempts(1); // speed up failures
     job.waitForCompletion(true);
     boolean succeeded = job.waitForCompletion(true);
-    assertTrue("The environment checker job failed.", succeeded);
+    assertTrue(succeeded, "The environment checker job failed.");
   }
   
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClasspath.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClasspath.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * A JUnit test to test Mini Map-Reduce Cluster with multiple directories
@@ -175,7 +175,7 @@ public class TestMiniMRClasspath {
       String result;
       result = launchWordCount(fileSys.getUri(), jobConf,
           "The quick brown fox\nhas many silly\n" + "red fox sox\n", 3, 1);
-      Assert.assertEquals("The\t1\nbrown\t1\nfox\t2\nhas\t1\nmany\t1\n"
+      Assertions.assertEquals("The\t1\nbrown\t1\nfox\t2\nhas\t1\nmany\t1\n"
           + "quick\t1\nred\t1\nsilly\t1\nsox\t1\n", result);
           
     } finally {
@@ -208,7 +208,7 @@ public class TestMiniMRClasspath {
       
       result = launchExternal(fileSys.getUri(), jobConf,
           "Dennis was here!\nDennis again!", 3, 1);
-      Assert.assertEquals("Dennis again!\t1\nDennis was here!\t1\n", result);
+      Assertions.assertEquals("Dennis again!\t1\nDennis was here!\t1\n", result);
       
     } 
     finally {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClientCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRClientCluster.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapred;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.StringTokenizer;
@@ -34,9 +34,9 @@ import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic testing for the MiniMRClientCluster. This test shows an example class
@@ -54,7 +54,7 @@ public class TestMiniMRClientCluster {
   private class InternalClass {
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     final Configuration conf = new Configuration();
     final Path TEST_ROOT_DIR = new Path(System.getProperty("test.build.data",
@@ -81,7 +81,7 @@ public class TestMiniMRClientCluster {
         InternalClass.class, 1, new Configuration());
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     // clean up the input and output files
     final Configuration conf = new Configuration();
@@ -128,27 +128,27 @@ public class TestMiniMRClientCluster {
     String mrHistWebAppAddress2 = mrCluster.getConfig().get(
         JHAdminConfig.MR_HISTORY_WEBAPP_ADDRESS);
 
-    assertEquals("Address before restart: " + rmAddress1
-        + " is different from new address: " + rmAddress2, rmAddress1,
-        rmAddress2);
-    assertEquals("Address before restart: " + rmAdminAddress1
-        + " is different from new address: " + rmAdminAddress2,
-        rmAdminAddress1, rmAdminAddress2);
-    assertEquals("Address before restart: " + rmSchedAddress1
-        + " is different from new address: " + rmSchedAddress2,
-        rmSchedAddress1, rmSchedAddress2);
-    assertEquals("Address before restart: " + rmRstrackerAddress1
-        + " is different from new address: " + rmRstrackerAddress2,
-        rmRstrackerAddress1, rmRstrackerAddress2);
-    assertEquals("Address before restart: " + rmWebAppAddress1
-        + " is different from new address: " + rmWebAppAddress2,
-        rmWebAppAddress1, rmWebAppAddress2);
-    assertEquals("Address before restart: " + mrHistAddress1
-        + " is different from new address: " + mrHistAddress2, mrHistAddress1,
-        mrHistAddress2);
-    assertEquals("Address before restart: " + mrHistWebAppAddress1
-        + " is different from new address: " + mrHistWebAppAddress2,
-        mrHistWebAppAddress1, mrHistWebAppAddress2);
+    assertEquals(rmAddress1
+,         rmAddress2, "Address before restart: " + rmAddress1
+        + " is different from new address: " + rmAddress2);
+    assertEquals(
+       rmAdminAddress1, rmAdminAddress2, "Address before restart: " + rmAdminAddress1
+        + " is different from new address: " + rmAdminAddress2);
+    assertEquals(
+       rmSchedAddress1, rmSchedAddress2, "Address before restart: " + rmSchedAddress1
+        + " is different from new address: " + rmSchedAddress2);
+    assertEquals(
+       rmRstrackerAddress1, rmRstrackerAddress2, "Address before restart: " + rmRstrackerAddress1
+        + " is different from new address: " + rmRstrackerAddress2);
+    assertEquals(
+       rmWebAppAddress1, rmWebAppAddress2, "Address before restart: " + rmWebAppAddress1
+        + " is different from new address: " + rmWebAppAddress2);
+    assertEquals(mrHistAddress1
+,         mrHistAddress2, "Address before restart: " + mrHistAddress1
+        + " is different from new address: " + mrHistAddress2);
+    assertEquals(
+       mrHistWebAppAddress1, mrHistWebAppAddress2, "Address before restart: " + mrHistWebAppAddress1
+        + " is different from new address: " + mrHistWebAppAddress2);
 
   }
 
@@ -165,14 +165,14 @@ public class TestMiniMRClientCluster {
 
   private void validateCounters(Counters counters, long mapInputRecords,
       long mapOutputRecords, long reduceInputGroups, long reduceOutputRecords) {
-    assertEquals("MapInputRecords", mapInputRecords, counters.findCounter(
-        "MyCounterGroup", "MAP_INPUT_RECORDS").getValue());
-    assertEquals("MapOutputRecords", mapOutputRecords, counters.findCounter(
-        "MyCounterGroup", "MAP_OUTPUT_RECORDS").getValue());
-    assertEquals("ReduceInputGroups", reduceInputGroups, counters.findCounter(
-        "MyCounterGroup", "REDUCE_INPUT_GROUPS").getValue());
-    assertEquals("ReduceOutputRecords", reduceOutputRecords, counters
-        .findCounter("MyCounterGroup", "REDUCE_OUTPUT_RECORDS").getValue());
+    assertEquals(mapInputRecords, counters.findCounter(
+        "MyCounterGroup", "MAP_INPUT_RECORDS").getValue(), "MapInputRecords");
+    assertEquals(mapOutputRecords, counters.findCounter(
+        "MyCounterGroup", "MAP_OUTPUT_RECORDS").getValue(), "MapOutputRecords");
+    assertEquals(reduceInputGroups, counters.findCounter(
+        "MyCounterGroup", "REDUCE_INPUT_GROUPS").getValue(), "ReduceInputGroups");
+    assertEquals(reduceOutputRecords, counters
+        .findCounter("MyCounterGroup", "REDUCE_OUTPUT_RECORDS").getValue(), "ReduceOutputRecords");
   }
 
   private static void createFile(Path inFile, Configuration conf)

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRDFSCaching.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRDFSCaching.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.MRCaching.TestResult;
 import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -52,7 +52,7 @@ public class TestMiniMRDFSCaching {
                                             mr.createJobConf(),
                                             "The quick brown fox\nhas many silly\n"
                                             + "red fox sox\n");
-      assertTrue("Archives not matching", ret.isOutputOk);
+      assertTrue(ret.isOutputOk, "Archives not matching");
       // launch MR cache with symlinks
       ret = MRCaching.launchMRCache("/testing/wc/input",
                                     "/testing/wc/output",
@@ -60,7 +60,7 @@ public class TestMiniMRDFSCaching {
                                     mr.createJobConf(),
                                     "The quick brown fox\nhas many silly\n"
                                     + "red fox sox\n");
-      assertTrue("Archives not matching", ret.isOutputOk);
+      assertTrue(ret.isOutputOk, "Archives not matching");
     } finally {
       if (fileSys != null) {
         fileSys.close();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRWithDFSWithDistinctUsers.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMiniMRWithDFSWithDistinctUsers.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A JUnit test to test Mini Map-Reduce Cluster with Mini-DFS.
@@ -70,10 +70,10 @@ public class TestMiniMRWithDFSWithDistinctUsers {
       });
 
     rj.waitForCompletion();
-    Assert.assertEquals("SUCCEEDED", JobStatus.getJobRunState(rj.getJobState()));
+    Assertions.assertEquals("SUCCEEDED", JobStatus.getJobRunState(rj.getJobState()));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     dfs = new MiniDFSCluster.Builder(conf).numDataNodes(4).build();
 
@@ -98,7 +98,7 @@ public class TestMiniMRWithDFSWithDistinctUsers {
                            1, null, null, MR_UGI, mrConf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (mr != null) { mr.shutdown();}
     if (dfs != null) { dfs.shutdown(); }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultiFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultiFileInputFormat.java
@@ -25,12 +25,12 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestMultiFileInputFormat {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultiFileSplit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultiFileSplit.java
@@ -28,11 +28,11 @@ import java.io.OutputStream;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleLevelCaching.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleLevelCaching.java
@@ -28,11 +28,11 @@ import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.mapreduce.JobCounter;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This test checks whether the task caches are created and used properly.
@@ -158,14 +158,14 @@ public class TestMultipleLevelCaching {
     }
     RunningJob job = launchJob(jobConf, in, out, numMaps, jobName);
     Counters counters = job.getCounters();
-    assertEquals("Number of local maps",
-            counters.getCounter(JobCounter.OTHER_LOCAL_MAPS), otherLocalMaps);
-    assertEquals("Number of Data-local maps",
-            counters.getCounter(JobCounter.DATA_LOCAL_MAPS),
-                                dataLocalMaps);
-    assertEquals("Number of Rack-local maps",
-            counters.getCounter(JobCounter.RACK_LOCAL_MAPS),
-                                rackLocalMaps);
+    assertEquals(
+           counters.getCounter(JobCounter.OTHER_LOCAL_MAPS), otherLocalMaps, "Number of local maps");
+    assertEquals(
+           counters.getCounter(JobCounter.DATA_LOCAL_MAPS)
+,                                 dataLocalMaps, "Number of Data-local maps");
+    assertEquals(
+           counters.getCounter(JobCounter.RACK_LOCAL_MAPS)
+,                                 rackLocalMaps, "Number of Rack-local maps");
     mr.waitUntilIdle();
     mr.shutdown();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestMultipleTextOutputFormat.java
@@ -22,13 +22,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.MultipleTextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestMultipleTextOutputFormat {
   private static JobConf defaultConf = new JobConf();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestNetworkedJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestNetworkedJob.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.mapred;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,7 +47,8 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnRuntimeException;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestNetworkedJob {
   private static String TEST_ROOT_DIR = new File(System.getProperty(
@@ -56,7 +57,8 @@ public class TestNetworkedJob {
   private static Path inFile = new Path(testDir, "in");
   private static Path outDir = new Path(testDir, "out");
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testGetNullCounters() throws Exception {
     //mock creation
     Job mockJob = mock(Job.class);
@@ -68,7 +70,8 @@ public class TestNetworkedJob {
     verify(mockJob).getCounters();
   }
   
-  @Test (timeout=500000)
+  @Test
+  @Timeout(value = 500)
   public void testGetJobStatus() throws IOException, InterruptedException,
       ClassNotFoundException {
     MiniMRClientCluster mr = null;
@@ -101,11 +104,11 @@ public class TestNetworkedJob {
 
       // The following asserts read JobStatus twice and ensure the returned
       // JobStatus objects correspond to the same Job.
-      assertEquals("Expected matching JobIDs", jobId, client.getJob(jobId)
-          .getJobStatus().getJobID());
-      assertEquals("Expected matching startTimes", rj.getJobStatus()
+      assertEquals(jobId, client.getJob(jobId)
+          .getJobStatus().getJobID(), "Expected matching JobIDs");
+      assertEquals(rj.getJobStatus()
           .getStartTime(), client.getJob(jobId).getJobStatus()
-          .getStartTime());
+          .getStartTime(), "Expected matching startTimes");
     } finally {
       if (fileSys != null) {
         fileSys.delete(testDir, true);
@@ -120,7 +123,8 @@ public class TestNetworkedJob {
  * @throws Exception
  */
   @SuppressWarnings( "deprecation" )
-  @Test (timeout=500000)
+  @Test
+  @Timeout(value = 500)
   public void testNetworkedJob() throws Exception {
     // mock creation
     MiniMRClientCluster mr = null;
@@ -252,10 +256,10 @@ public class TestNetworkedJob {
       // test JobClient
       // The following asserts read JobStatus twice and ensure the returned
       // JobStatus objects correspond to the same Job.
-      assertEquals("Expected matching JobIDs", jobId, client.getJob(jobId)
-          .getJobStatus().getJobID());
-      assertEquals("Expected matching startTimes", rj.getJobStatus()
-          .getStartTime(), client.getJob(jobId).getJobStatus().getStartTime());
+      assertEquals(jobId, client.getJob(jobId)
+          .getJobStatus().getJobID(), "Expected matching JobIDs");
+      assertEquals(rj.getJobStatus()
+          .getStartTime(), client.getJob(jobId).getJobStatus().getStartTime(), "Expected matching startTimes");
     } finally {
       if (fileSys != null) {
         fileSys.delete(testDir, true);
@@ -271,7 +275,8 @@ public class TestNetworkedJob {
    * 
    * @throws IOException
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testBlackListInfo() throws IOException {
     BlackListInfo info = new BlackListInfo();
     info.setBlackListReport("blackListInfo");
@@ -293,7 +298,8 @@ public class TestNetworkedJob {
  *  test run from command line JobQueueClient
  * @throws Exception
  */
-  @Test (timeout=500000)
+  @Test
+  @Timeout(value = 500)
   public void testJobQueueClient() throws Exception {
         MiniMRClientCluster mr = null;
     FileSystem fileSys = null;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestOldCombinerGrouping.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapred;
 
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
@@ -28,7 +28,7 @@ import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.test.GenericTestUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -119,7 +119,7 @@ public class TestOldCombinerGrouping {
 
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(testRootDir);
   }
@@ -169,30 +169,30 @@ public class TestOldCombinerGrouping {
       long combinerOutputRecords = counters.getGroup(
           "org.apache.hadoop.mapreduce.TaskCounter").
           getCounter("COMBINE_OUTPUT_RECORDS");
-      Assert.assertTrue(combinerInputRecords > 0);
-      Assert.assertTrue(combinerInputRecords > combinerOutputRecords);
+      Assertions.assertTrue(combinerInputRecords > 0);
+      Assertions.assertTrue(combinerInputRecords > combinerOutputRecords);
 
       BufferedReader br = new BufferedReader(new FileReader(
           new File(out, "part-00000")));
       Set<String> output = new HashSet<String>();
       String line = br.readLine();
-      Assert.assertNotNull(line);
+      Assertions.assertNotNull(line);
       output.add(line.substring(0, 1) + line.substring(4, 5));
       line = br.readLine();
-      Assert.assertNotNull(line);
+      Assertions.assertNotNull(line);
       output.add(line.substring(0, 1) + line.substring(4, 5));
       line = br.readLine();
-      Assert.assertNull(line);
+      Assertions.assertNull(line);
       br.close();
 
       Set<String> expected = new HashSet<String>();
       expected.add("A2");
       expected.add("B5");
 
-      Assert.assertEquals(expected, output);
+      Assertions.assertEquals(expected, output);
 
     } else {
-      Assert.fail("Job failed");
+      Assertions.fail("Job failed");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestQueueConfigurationParser.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestQueueConfigurationParser.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.util.XMLUtils;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestQueueConfigurationParser {
 /**
@@ -42,7 +43,8 @@ public class TestQueueConfigurationParser {
  * @throws ParserConfigurationException
  * @throws Exception 
  */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testQueueConfigurationParser()
       throws ParserConfigurationException, Exception {
     JobQueueInfo info = new JobQueueInfo("root", "rootInfo");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceFetch.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceFetch.java
@@ -19,10 +19,10 @@
 package org.apache.hadoop.mapred;
 
 import org.apache.hadoop.mapreduce.TaskCounter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestReduceFetch extends TestReduceFetchFromPartialMem {
 
@@ -44,10 +44,10 @@ public class TestReduceFetch extends TestReduceFetchFromPartialMem {
     Counters c = runJob(job);
     final long spill = c.findCounter(TaskCounter.SPILLED_RECORDS).getCounter();
     final long out = c.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getCounter();
-    assertTrue("Expected all records spilled during reduce (" + spill + ")",
-        spill >= 2 * out); // all records spill at map, reduce
-    assertTrue("Expected intermediate merges (" + spill + ")",
-        spill >= 2 * out + (out / MAP_TASKS)); // some records hit twice
+    assertTrue(
+       spill >= 2 * out, "Expected all records spilled during reduce (" + spill + ")"); // all records spill at map, reduce
+    assertTrue(
+       spill >= 2 * out + (out / MAP_TASKS), "Expected intermediate merges (" + spill + ")"); // some records hit twice
   }
 
   /**
@@ -65,6 +65,6 @@ public class TestReduceFetch extends TestReduceFetchFromPartialMem {
     Counters c = runJob(job);
     final long spill = c.findCounter(TaskCounter.SPILLED_RECORDS).getCounter();
     final long out = c.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getCounter();
-    assertEquals("Spilled records: " + spill, out, spill); // no reduce spill
+    assertEquals(out, spill, "Spilled records: " + spill); // no reduce spill
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceFetchFromPartialMem.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceFetchFromPartialMem.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.task.reduce.Fetcher;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -39,16 +39,16 @@ import java.util.Formatter;
 import java.util.Iterator;
 
 import static org.apache.hadoop.mapreduce.task.reduce.Fetcher.SHUFFLE_ERR_GRP_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestReduceFetchFromPartialMem {
 
   protected static MiniMRCluster mrCluster = null;
   protected static MiniDFSCluster dfsCluster = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration conf = new Configuration();
     dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
@@ -56,7 +56,7 @@ public class TestReduceFetchFromPartialMem {
       dfsCluster.getFileSystem().getUri().toString(), 1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (dfsCluster != null) { dfsCluster.shutdown(); }
     if (mrCluster != null) { mrCluster.shutdown(); }
@@ -87,8 +87,8 @@ public class TestReduceFetchFromPartialMem {
     Counters c = runJob(job);
     final long out = c.findCounter(TaskCounter.MAP_OUTPUT_RECORDS).getCounter();
     final long spill = c.findCounter(TaskCounter.SPILLED_RECORDS).getCounter();
-    assertTrue("Expected some records not spilled during reduce" + spill + ")",
-        spill < 2 * out); // spilled map records, some records at the reduce
+    assertTrue(
+       spill < 2 * out, "Expected some records not spilled during reduce" + spill + ")"); // spilled map records, some records at the reduce
     long shuffleIoErrors =
         c.getGroup(SHUFFLE_ERR_GRP_NAME).getCounter(Fetcher.ShuffleErrors.IO_ERROR.toString());
     assertEquals(0, shuffleIoErrors);
@@ -226,8 +226,8 @@ public class TestReduceFetchFromPartialMem {
         out.collect(key, val);
         ++nRec;
       }
-      assertEquals("Bad rec count for " + key, recCheck, nRec - preRec);
-      assertEquals("Bad rec group for " + key, vcCheck, vc);
+      assertEquals(recCheck, nRec - preRec, "Bad rec count for " + key);
+      assertEquals(vcCheck, vc, "Bad rec group for " + key);
     }
 
     @Override
@@ -235,7 +235,7 @@ public class TestReduceFetchFromPartialMem {
       assertEquals(4095, nKey);
       assertEquals(nMaps - 1, aKey);
       assertEquals(nMaps - 1, bKey);
-      assertEquals("Bad record count", nMaps * (4096 + 2), nRec);
+      assertEquals(nMaps * (4096 + 2), nRec, "Bad record count");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceTask.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReduceTask.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.util.Progressable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test exercises the ValueIterator.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReporter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestReporter.java
@@ -31,11 +31,11 @@ import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests the old mapred APIs with {@link Reporter#getProgress()}.
@@ -48,14 +48,14 @@ public class TestReporter {
   
   private static FileSystem fs = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     fs = FileSystem.getLocal(new Configuration());
     fs.delete(testRootTempDir, true);
     fs.mkdirs(testRootTempDir);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     fs.delete(testRootTempDir, true);
   }
@@ -92,16 +92,16 @@ public class TestReporter {
       float mapProgress = ((float)++numRecords)/INPUT_LINES;
       // calculate the attempt progress based on the progress range
       float attemptProgress = progressRange * mapProgress;
-      assertEquals("Invalid progress in map", 
-                   attemptProgress, reporter.getProgress(), 0f);
+      assertEquals(attemptProgress, reporter.getProgress(), 0f,
+          "Invalid progress in map");
       output.collect(new Text(value.toString() + numRecords), value);
     }
     
     @Override
     public void close() throws IOException {
       super.close();
-      assertEquals("Invalid progress in map cleanup", 
-                   progressRange, reporter.getProgress(), 0f);
+      assertEquals(progressRange, reporter.getProgress(), 0f,
+          "Invalid progress in map cleanup");
     }
   }
 
@@ -147,7 +147,7 @@ public class TestReporter {
                            1, 0, INPUT);
     job.waitForCompletion();
     
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
   }
   
   /**
@@ -175,18 +175,17 @@ public class TestReporter {
     throws IOException {
       float reducePhaseProgress = ((float)++recordCount)/INPUT_LINES;
       float weightedReducePhaseProgress = 
-              reducePhaseProgress * REDUCE_PROGRESS_RANGE;
-      assertEquals("Invalid progress in reduce", 
-                   SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress, 
-                   reporter.getProgress(), 0.02f);
+         reducePhaseProgress * REDUCE_PROGRESS_RANGE;
+      assertEquals(SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress,
+          reporter.getProgress(), 0.02f, "Invalid progress in reduce");
       this.reporter = reporter;
     }
     
     @Override
     public void close() throws IOException {
       super.close();
-      assertEquals("Invalid progress in reduce cleanup", 
-                   1.0f, reporter.getProgress(), 0f);
+      assertEquals(1.0f, reporter.getProgress(), 0f,
+          "Invalid progress in reduce cleanup");
     }
   }
   
@@ -210,7 +209,7 @@ public class TestReporter {
                            1, 1, INPUT);
     job.waitForCompletion();
     
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
   }
 
   @Test
@@ -244,7 +243,7 @@ public class TestReporter {
 
     job.waitForCompletion(true);
 
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestResourceMgrDelegate.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestResourceMgrDelegate.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.JobStatus.State;
@@ -41,7 +41,7 @@ import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -69,7 +69,7 @@ public class TestResourceMgrDelegate {
       new YarnConfiguration()) {
       @Override
       protected void serviceStart() throws Exception {
-        Assert.assertTrue(this.client instanceof YarnClientImpl);
+        Assertions.assertTrue(this.client instanceof YarnClientImpl);
         ((YarnClientImpl) this.client).setRMClient(applicationsManager);
       }
     };
@@ -84,10 +84,10 @@ public class TestResourceMgrDelegate {
       throw new IOException(e);
     }
 
-    Assert.assertTrue("Children of root queue not requested",
-      argument.getValue().getIncludeChildQueues());
-    Assert.assertTrue("Request wasn't to recurse through children",
-      argument.getValue().getRecursive());
+    Assertions.assertTrue(
+     argument.getValue().getIncludeChildQueues(), "Children of root queue not requested");
+    Assertions.assertTrue(
+     argument.getValue().getRecursive(), "Request wasn't to recurse through children");
   }
 
   @Test
@@ -113,16 +113,16 @@ public class TestResourceMgrDelegate {
       new YarnConfiguration()) {
       @Override
       protected void serviceStart() throws Exception {
-        Assert.assertTrue(this.client instanceof YarnClientImpl);
+        Assertions.assertTrue(this.client instanceof YarnClientImpl);
         ((YarnClientImpl) this.client).setRMClient(applicationsManager);
       }
     };
     JobStatus[] allJobs = resourceMgrDelegate.getAllJobs();
 
-    Assert.assertEquals(State.FAILED, allJobs[0].getState());
-    Assert.assertEquals(State.SUCCEEDED, allJobs[1].getState());
-    Assert.assertEquals(State.KILLED, allJobs[2].getState());
-    Assert.assertEquals(State.FAILED, allJobs[3].getState());
+    Assertions.assertEquals(State.FAILED, allJobs[0].getState());
+    Assertions.assertEquals(State.SUCCEEDED, allJobs[1].getState());
+    Assertions.assertEquals(State.KILLED, allJobs[2].getState());
+    Assertions.assertEquals(State.FAILED, allJobs[3].getState());
   }
 
   private ApplicationReport getApplicationReport(

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsBinaryInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsBinaryInputFormat.java
@@ -25,13 +25,13 @@ import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSequenceFileAsBinaryInputFormat {
   private static final Logger LOG = FileInputFormat.LOG;
@@ -89,20 +89,20 @@ public class TestSequenceFileAsBinaryInputFormat {
           buf.reset(bval.getBytes(), bval.getLength());
           cmpval.readFields(buf);
           assertTrue(
-              "Keys don't match: " + "*" + cmpkey.toString() + ":" +
-                                           tkey.toString() + "*",
-              cmpkey.toString().equals(tkey.toString()));
+          
+             cmpkey.toString().equals(tkey.toString()), "Keys don't match: " + "*" + cmpkey.toString() + ":" +
+                                           tkey.toString() + "*");
           assertTrue(
-              "Vals don't match: " + "*" + cmpval.toString() + ":" +
-                                           tval.toString() + "*",
-              cmpval.toString().equals(tval.toString()));
+          
+             cmpval.toString().equals(tval.toString()), "Vals don't match: " + "*" + cmpval.toString() + ":" +
+                                           tval.toString() + "*");
           ++count;
         }
       } finally {
         reader.close();
       }
     }
-    assertEquals("Some records not found", RECORDS, count);
+    assertEquals(RECORDS, count, "Some records not found");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsBinaryOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsBinaryOutputFormat.java
@@ -30,13 +30,13 @@ import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestSequenceFileAsBinaryOutputFormat {
   private static final Logger LOG =
@@ -123,9 +123,9 @@ public class TestSequenceFileAsBinaryOutputFormat {
           sourceInt = r.nextInt();
           sourceDouble = r.nextDouble();
           assertEquals(
-              "Keys don't match: " + "*" + iwritable.get() + ":" + 
-                                           sourceInt + "*",
-              sourceInt, iwritable.get());
+          
+             sourceInt, iwritable.get(), "Keys don't match: " + "*" + iwritable.get() + ":" + 
+                                           sourceInt + "*");
           assertThat(dwritable.get()).withFailMessage(
               "Vals don't match: " + "*" + dwritable.get() + ":" +
                   sourceDouble + "*")
@@ -136,7 +136,7 @@ public class TestSequenceFileAsBinaryOutputFormat {
         reader.close();
       }
     }
-    assertEquals("Some records not found", RECORDS, count);
+    assertEquals(RECORDS, count, "Some records not found");
   }
 
   @Test
@@ -149,29 +149,29 @@ public class TestSequenceFileAsBinaryOutputFormat {
     job.setOutputKeyClass(FloatWritable.class);
     job.setOutputValueClass(BooleanWritable.class);
 
-    assertEquals("SequenceFileOutputKeyClass should default to ouputKeyClass", 
-             FloatWritable.class,
-             SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(
-                                                                         job));
-    assertEquals("SequenceFileOutputValueClass should default to " 
-             + "ouputValueClass", 
-             BooleanWritable.class,
-             SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(
-                                                                         job));
+    assertEquals(
+             FloatWritable.class
+,              SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(
+                                                                         job), "SequenceFileOutputKeyClass should default to ouputKeyClass");
+    assertEquals(
+             BooleanWritable.class
+,              SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(
+                                                                         job), "SequenceFileOutputValueClass should default to " 
+             + "ouputValueClass");
 
     SequenceFileAsBinaryOutputFormat.setSequenceFileOutputKeyClass(job, 
                                           IntWritable.class );
     SequenceFileAsBinaryOutputFormat.setSequenceFileOutputValueClass(job, 
                                           DoubleWritable.class ); 
 
-    assertEquals("SequenceFileOutputKeyClass not updated", 
-             IntWritable.class,
-             SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(
-                                                                         job));
-    assertEquals("SequenceFileOutputValueClass not updated", 
-             DoubleWritable.class,
-             SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(
-                                                                         job));
+    assertEquals(
+             IntWritable.class
+,              SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(
+                                                                         job), "SequenceFileOutputKeyClass not updated");
+    assertEquals(
+             DoubleWritable.class
+,              SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(
+                                                                         job), "SequenceFileOutputValueClass not updated");
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileAsTextInputFormat.java
@@ -26,13 +26,13 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestSequenceFileAsTextInputFormat {
   private static final Logger LOG = FileInputFormat.LOG;
@@ -94,7 +94,7 @@ public class TestSequenceFileAsTextInputFormat {
           RecordReader<Text, Text> reader =
             format.getRecordReader(splits[j], job, reporter);
           Class readerClass = reader.getClass();
-          assertEquals("reader class is SequenceFileAsTextRecordReader.", SequenceFileAsTextRecordReader.class, readerClass);        
+          assertEquals(SequenceFileAsTextRecordReader.class, readerClass, "reader class is SequenceFileAsTextRecordReader.");        
           Text value = reader.createValue();
           Text key = reader.createKey();
           try {
@@ -105,7 +105,7 @@ public class TestSequenceFileAsTextInputFormat {
               // LOG.info("@"+reader.getPos());
               // }
               int keyInt = Integer.parseInt(key.toString());
-              assertFalse("Key in multiple partitions.", bits.get(keyInt));
+              assertFalse(bits.get(keyInt), "Key in multiple partitions.");
               bits.set(keyInt);
               count++;
             }
@@ -114,7 +114,7 @@ public class TestSequenceFileAsTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileInputFilter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileInputFilter.java
@@ -25,13 +25,13 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSequenceFileInputFilter {
   private static final Logger LOG = FileInputFormat.LOG;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSequenceFileInputFormat.java
@@ -25,13 +25,13 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.slf4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestSequenceFileInputFormat {
   private static final Logger LOG = FileInputFormat.LOG;
@@ -102,7 +102,7 @@ public class TestSequenceFileInputFormat {
               // LOG.info("splits["+j+"]="+splits[j]+" : " + key.get());
               // LOG.info("@"+reader.getPos());
               // }
-              assertFalse("Key in multiple partitions.", bits.get(key.get()));
+              assertFalse(bits.get(key.get()), "Key in multiple partitions.");
               bits.set(key.get());
               count++;
             }
@@ -111,7 +111,7 @@ public class TestSequenceFileInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSortedRanges.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSortedRanges.java
@@ -18,13 +18,13 @@
 package org.apache.hadoop.mapred;
 
 import org.apache.hadoop.mapred.SortedRanges.Range;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSortedRanges {
   private static final Logger LOG =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSpecialCharactersInOutputPath.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestSpecialCharactersInOutputPath.java
@@ -30,12 +30,12 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.util.Progressable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A JUnit test to test that jobs' output filenames are not HTML-encoded (cf HADOOP-1795).
@@ -85,7 +85,7 @@ public class TestSpecialCharactersInOutputPath {
     try {
       assertTrue(runningJob.isComplete());
       assertTrue(runningJob.isSuccessful());
-      assertTrue("Output folder not found!", fs.exists(new Path("/testing/output/" + OUTPUT_FILENAME)));
+      assertTrue(fs.exists(new Path("/testing/output/" + OUTPUT_FILENAME)), "Output folder not found!");
     } catch (NullPointerException npe) {
       // This NPE should no more happens
       fail("A NPE should not have happened.");

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestStatisticsCollector.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestStatisticsCollector.java
@@ -21,12 +21,12 @@ import java.util.Map;
 
 import org.apache.hadoop.mapred.StatisticsCollector.TimeWindow;
 import org.apache.hadoop.mapred.StatisticsCollector.Stat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestStatisticsCollector {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskCommit.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskCommit.java
@@ -25,16 +25,16 @@ import org.apache.hadoop.ipc.ProtocolSignature;
 import org.apache.hadoop.mapred.SortedRanges.Range;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.checkpoint.TaskCheckpointID;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 
@@ -86,7 +86,7 @@ public class TestTaskCommit extends HadoopTestCase {
     super(LOCAL_MR, LOCAL_FS, 1, 1);
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     super.tearDown();
     FileUtil.fullyDelete(new File(rootDir.toString()));
@@ -250,43 +250,43 @@ public class TestTaskCommit extends HadoopTestCase {
     task.setTaskCleanupTask();
     MyUmbilical umbilical = new MyUmbilical();
     task.run(job, umbilical);
-    assertTrue("Task did not succeed", umbilical.taskDone);
+    assertTrue(umbilical.taskDone, "Task did not succeed");
   }
 
   @Test
   public void testCommitRequiredForMapTask() throws Exception {
     Task testTask = createDummyTask(TaskType.MAP);
-    assertTrue("MapTask should need commit", testTask.isCommitRequired());
+    assertTrue(testTask.isCommitRequired(), "MapTask should need commit");
   }
 
   @Test
   public void testCommitRequiredForReduceTask() throws Exception {
     Task testTask = createDummyTask(TaskType.REDUCE);
-    assertTrue("ReduceTask should need commit", testTask.isCommitRequired());
+    assertTrue(testTask.isCommitRequired(), "ReduceTask should need commit");
   }
 
   @Test
   public void testCommitNotRequiredForJobSetup() throws Exception {
     Task testTask = createDummyTask(TaskType.MAP);
     testTask.setJobSetupTask();
-    assertFalse("Job setup task should not need commit", 
-        testTask.isCommitRequired());
+    assertFalse(
+        testTask.isCommitRequired(), "Job setup task should not need commit");
   }
 
   @Test
   public void testCommitNotRequiredForJobCleanup() throws Exception {
     Task testTask = createDummyTask(TaskType.MAP);
     testTask.setJobCleanupTask();
-    assertFalse("Job cleanup task should not need commit", 
-        testTask.isCommitRequired());
+    assertFalse(
+        testTask.isCommitRequired(), "Job cleanup task should not need commit");
   }
 
   @Test
   public void testCommitNotRequiredForTaskCleanup() throws Exception {
     Task testTask = createDummyTask(TaskType.REDUCE);
     testTask.setTaskCleanupTask();
-    assertFalse("Task cleanup task should not need commit", 
-        testTask.isCommitRequired());
+    assertFalse(
+        testTask.isCommitRequired(), "Task cleanup task should not need commit");
   }
 
   private Task createDummyTask(TaskType type) throws IOException, ClassNotFoundException,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskPerformanceSplits.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskPerformanceSplits.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapred;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTaskPerformanceSplits {
   @Test
@@ -40,15 +40,15 @@ public class TestTaskPerformanceSplits {
       System.err.println("segment i = " + results[i]);
     }
 
-    assertEquals("Bad interpolation in cumulative segment 0", 200, results[0]);
-    assertEquals("Bad interpolation in cumulative segment 1", 200, results[1]);
-    assertEquals("Bad interpolation in cumulative segment 2", 200, results[2]);
-    assertEquals("Bad interpolation in cumulative segment 3", 300, results[3]);
-    assertEquals("Bad interpolation in cumulative segment 4", 400, results[4]);
-    assertEquals("Bad interpolation in cumulative segment 5", 2200, results[5]);
+    assertEquals(200, results[0], "Bad interpolation in cumulative segment 0");
+    assertEquals(200, results[1], "Bad interpolation in cumulative segment 1");
+    assertEquals(200, results[2], "Bad interpolation in cumulative segment 2");
+    assertEquals(300, results[3], "Bad interpolation in cumulative segment 3");
+    assertEquals(400, results[4], "Bad interpolation in cumulative segment 4");
+    assertEquals(2200, results[5], "Bad interpolation in cumulative segment 5");
     // these are rounded down
-    assertEquals("Bad interpolation in cumulative segment 6", 2200, results[6]);
-    assertEquals("Bad interpolation in cumulative segment 7", 2201, results[7]);
+    assertEquals(2200, results[6], "Bad interpolation in cumulative segment 6");
+    assertEquals(2201, results[7], "Bad interpolation in cumulative segment 7");
 
     status.extend(0.0D, 0);
     status.extend(1.0D/16.0D, 300); // + 75 for bucket 0
@@ -59,13 +59,13 @@ public class TestTaskPerformanceSplits {
 
     results = status.getValues();
 
-    assertEquals("Bad interpolation in status segment 0", 275, results[0]);
-    assertEquals("Bad interpolation in status segment 1", 750, results[1]);
-    assertEquals("Bad interpolation in status segment 2", 1500, results[2]);
-    assertEquals("Bad interpolation in status segment 3", 2175, results[3]);
-    assertEquals("Bad interpolation in status segment 4", 2100, results[4]);
-    assertEquals("Bad interpolation in status segment 5", 1900, results[5]);
-    assertEquals("Bad interpolation in status segment 6", 1700, results[6]);
-    assertEquals("Bad interpolation in status segment 7", 1500, results[7]);
+    assertEquals(275, results[0], "Bad interpolation in status segment 0");
+    assertEquals(750, results[1], "Bad interpolation in status segment 1");
+    assertEquals(1500, results[2], "Bad interpolation in status segment 2");
+    assertEquals(2175, results[3], "Bad interpolation in status segment 3");
+    assertEquals(2100, results[4], "Bad interpolation in status segment 4");
+    assertEquals(1900, results[5], "Bad interpolation in status segment 5");
+    assertEquals(1700, results[6], "Bad interpolation in status segment 6");
+    assertEquals(1500, results[7], "Bad interpolation in status segment 7");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskStatus.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTaskStatus.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.mapred;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTaskStatus {
 
@@ -52,25 +52,25 @@ public class TestTaskStatus {
     // first try to set the finish time before
     // start time is set.
     status.setFinishTime(currentTime);
-    assertEquals("Finish time of the task status set without start time", 0,
-        status.getFinishTime());
+    assertEquals(0
+,         status.getFinishTime(), "Finish time of the task status set without start time");
     // Now set the start time to right time.
     status.setStartTime(currentTime);
-    assertEquals("Start time of the task status not set correctly.",
-        currentTime, status.getStartTime());
+    assertEquals(
+       currentTime, status.getStartTime(), "Start time of the task status not set correctly.");
     // try setting wrong start time to task status.
     long wrongTime = -1;
     status.setStartTime(wrongTime);
     assertEquals(
-        "Start time of the task status is set to wrong negative value",
-        currentTime, status.getStartTime());
+    
+       currentTime, status.getStartTime(), "Start time of the task status is set to wrong negative value");
     // finally try setting wrong finish time i.e. negative value.
     status.setFinishTime(wrongTime);
-    assertEquals("Finish time of task status is set to wrong negative value",
-        0, status.getFinishTime());
+    assertEquals(
+       0, status.getFinishTime(), "Finish time of task status is set to wrong negative value");
     status.setFinishTime(currentTime);
-    assertEquals("Finish time of the task status not set correctly.",
-        currentTime, status.getFinishTime());
+    assertEquals(
+       currentTime, status.getFinishTime(), "Finish time of the task status not set correctly.");
     
     // test with null task-diagnostics
     TaskStatus ts = ((TaskStatus)status.clone());
@@ -117,19 +117,19 @@ public class TestTaskStatus {
         return false;
       }
     };
-    assertEquals("Small diagnostic info test failed", 
-                 status.getDiagnosticInfo(), test);
-    assertEquals("Small state string test failed", status.getStateString(), 
-                 test);
+    assertEquals(
+                 status.getDiagnosticInfo(), test, "Small diagnostic info test failed");
+    assertEquals(status.getStateString(), 
+                 test, "Small state string test failed");
     
     // now append some small string and check
     String newDInfo = test.concat(test);
     status.setDiagnosticInfo(test);
     status.setStateString(newDInfo);
-    assertEquals("Small diagnostic info append failed", 
-                 newDInfo, status.getDiagnosticInfo());
-    assertEquals("Small state-string append failed", 
-                 newDInfo, status.getStateString());
+    assertEquals(
+                 newDInfo, status.getDiagnosticInfo(), "Small diagnostic info append failed");
+    assertEquals(
+                 newDInfo, status.getStateString(), "Small state-string append failed");
     
     // update the status with small state strings
     TaskStatus newStatus = (TaskStatus)status.clone();
@@ -138,47 +138,47 @@ public class TestTaskStatus {
     status.statusUpdate(newStatus);
     newDInfo = newDInfo.concat(newStatus.getDiagnosticInfo());
     
-    assertEquals("Status-update on diagnostic-info failed", 
-                 newDInfo, status.getDiagnosticInfo());
-    assertEquals("Status-update on state-string failed", 
-                 newSInfo, status.getStateString());
+    assertEquals(
+                 newDInfo, status.getDiagnosticInfo(), "Status-update on diagnostic-info failed");
+    assertEquals(
+                 newSInfo, status.getStateString(), "Status-update on state-string failed");
     
     newSInfo = "hi2";
     status.statusUpdate(0, newSInfo, null);
-    assertEquals("Status-update on state-string failed", 
-                 newSInfo, status.getStateString());
+    assertEquals(
+                 newSInfo, status.getStateString(), "Status-update on state-string failed");
     
     newSInfo = "hi3";
     status.statusUpdate(null, 0, newSInfo, null, 0);
-    assertEquals("Status-update on state-string failed", 
-                 newSInfo, status.getStateString());
+    assertEquals(
+                 newSInfo, status.getStateString(), "Status-update on state-string failed");
     
     
     // now append each with large string
     String large = "hihihihihihihihihihi"; // 20 chars
     status.setDiagnosticInfo(large);
     status.setStateString(large);
-    assertEquals("Large diagnostic info append test failed", 
-                 maxSize, status.getDiagnosticInfo().length());
-    assertEquals("Large state-string append test failed",
-                 maxSize, status.getStateString().length());
+    assertEquals(
+                 maxSize, status.getDiagnosticInfo().length(), "Large diagnostic info append test failed");
+    assertEquals(
+                maxSize, status.getStateString().length(), "Large state-string append test failed");
     
     // update a large status with large strings
     newStatus.setDiagnosticInfo(large + "0");
     newStatus.setStateString(large + "1");
     status.statusUpdate(newStatus);
-    assertEquals("Status-update on diagnostic info failed",
-                 maxSize, status.getDiagnosticInfo().length());
-    assertEquals("Status-update on state-string failed", 
-                 maxSize, status.getStateString().length());
+    assertEquals(
+                maxSize, status.getDiagnosticInfo().length(), "Status-update on diagnostic info failed");
+    assertEquals(
+                 maxSize, status.getStateString().length(), "Status-update on state-string failed");
     
     status.statusUpdate(0, large + "2", null);
-    assertEquals("Status-update on state-string failed", 
-                 maxSize, status.getStateString().length());
+    assertEquals(
+                 maxSize, status.getStateString().length(), "Status-update on state-string failed");
     
     status.statusUpdate(null, 0, large + "3", null, 0);
-    assertEquals("Status-update on state-string failed", 
-                 maxSize, status.getStateString().length());
+    assertEquals(
+                 maxSize, status.getStateString().length(), "Status-update on state-string failed");
     
     // test passing large string in constructor
     status = new TaskStatus(null, 0, 0, null, large, large, null, null, 
@@ -197,9 +197,9 @@ public class TestTaskStatus {
         return false;
       }
     };
-    assertEquals("Large diagnostic info test failed", 
-                maxSize, status.getDiagnosticInfo().length());
-    assertEquals("Large state-string test failed", 
-                 maxSize, status.getStateString().length());
+    assertEquals(
+                maxSize, status.getDiagnosticInfo().length(), "Large diagnostic info test failed");
+    assertEquals(
+                 maxSize, status.getStateString().length(), "Large state-string test failed");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextInputFormat.java
@@ -38,12 +38,13 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.*;
 import org.apache.hadoop.util.LineReader;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestTextInputFormat {
   private static final Logger LOG =
@@ -66,7 +67,8 @@ public class TestTextInputFormat {
       System.getProperty("test.build.data", "/tmp"),
       "TestTextInputFormat"));
 
-  @Test (timeout=500000)
+  @Test
+  @Timeout(value = 500)
   public void testFormat() throws Exception {
     JobConf job = new JobConf(defaultConf);
     Path file = new Path(workDir, "test.txt");
@@ -110,9 +112,9 @@ public class TestTextInputFormat {
         LOG.debug("splitting: got =        " + splits.length);
 
         if (length == 0) {
-           assertEquals("Files of length 0 are not returned from FileInputFormat.getSplits().", 
-                        1, splits.length);
-           assertEquals("Empty file length == 0", 0, splits[0].getLength());
+           assertEquals(
+                        1, splits.length, "Files of length 0 are not returned from FileInputFormat.getSplits().");
+           assertEquals(0, splits[0].getLength(), "Empty file length == 0");
         }
 
         // check each split
@@ -131,7 +133,7 @@ public class TestTextInputFormat {
                          " in split " + j +
                          " at position "+reader.getPos());
               }
-              assertFalse("Key in multiple partitions.", bits.get(v));
+              assertFalse(bits.get(v), "Key in multiple partitions.");
               bits.set(v);
               count++;
             }
@@ -140,13 +142,14 @@ public class TestTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }
   }
 
-  @Test (timeout=900000)
+  @Test
+  @Timeout(value = 900)
   public void testSplitableCodecs() throws IOException {
     JobConf conf = new JobConf(defaultConf);
     int seed = new Random().nextInt();
@@ -195,7 +198,8 @@ public class TestTextInputFormat {
   }
 
   // Test a corner case when position of stream is right after BZip2 marker
-  @Test (timeout=900000)
+  @Test
+  @Timeout(value = 900)
   public void testSplitableCodecs2() throws IOException {
     JobConf conf = new JobConf(defaultConf);
     // Create the codec
@@ -253,7 +257,7 @@ public class TestTextInputFormat {
               LOG.warn("conflict with " + v + " in split " + j +
                   " at position " + reader.getPos());
             }
-            assertFalse("Key in multiple partitions.", bits.get(v));
+            assertFalse(bits.get(v), "Key in multiple partitions.");
             bits.set(v);
             counter++;
           }
@@ -266,7 +270,7 @@ public class TestTextInputFormat {
           reader.close();
         }
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 
@@ -314,7 +318,7 @@ public class TestTextInputFormat {
                     " in split " + j +
                     " at position "+reader.getPos());
           }
-          assertFalse("Key in multiple partitions.", bits.get(v));
+          assertFalse(bits.get(v), "Key in multiple partitions.");
           bits.set(v);
           counter++;
         }
@@ -327,7 +331,7 @@ public class TestTextInputFormat {
         reader.close();
       }
     }
-    assertEquals("Some keys in no partition.", length, bits.cardinality());
+    assertEquals(length, bits.cardinality(), "Some keys in no partition.");
   }
 
   private static LineReader makeStream(String str) throws IOException {
@@ -337,7 +341,8 @@ public class TestTextInputFormat {
     return new LineReader(new ByteArrayInputStream(str.getBytes(UTF_8)), bufsz);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testUTF8() throws Exception {
     LineReader in = makeStream("abcd\u20acbdcd\u20ac");
     Text line = new Text();
@@ -356,7 +361,8 @@ public class TestTextInputFormat {
    *
    * @throws Exception
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testNewLines() throws Exception {
     final String STR = "a\nbb\n\nccc\rdddd\r\r\r\n\r\neeeee";
     final int STRLENBYTES = STR.getBytes().length;
@@ -365,25 +371,25 @@ public class TestTextInputFormat {
       LineReader in = makeStream(STR, bufsz);
       int c = 0;
       c += in.readLine(out); //"a"\n
-      assertEquals("line1 length, bufsz:"+bufsz, 1, out.getLength());
+      assertEquals(1, out.getLength(), "line1 length, bufsz:"+bufsz);
       c += in.readLine(out); //"bb"\n
-      assertEquals("line2 length, bufsz:"+bufsz, 2, out.getLength());
+      assertEquals(2, out.getLength(), "line2 length, bufsz:"+bufsz);
       c += in.readLine(out); //""\n
-      assertEquals("line3 length, bufsz:"+bufsz, 0, out.getLength());
+      assertEquals(0, out.getLength(), "line3 length, bufsz:"+bufsz);
       c += in.readLine(out); //"ccc"\r
-      assertEquals("line4 length, bufsz:"+bufsz, 3, out.getLength());
+      assertEquals(3, out.getLength(), "line4 length, bufsz:"+bufsz);
       c += in.readLine(out); //dddd\r
-      assertEquals("line5 length, bufsz:"+bufsz, 4, out.getLength());
+      assertEquals(4, out.getLength(), "line5 length, bufsz:"+bufsz);
       c += in.readLine(out); //""\r
-      assertEquals("line6 length, bufsz:"+bufsz, 0, out.getLength());
+      assertEquals(0, out.getLength(), "line6 length, bufsz:"+bufsz);
       c += in.readLine(out); //""\r\n
-      assertEquals("line7 length, bufsz:"+bufsz, 0, out.getLength());
+      assertEquals(0, out.getLength(), "line7 length, bufsz:"+bufsz);
       c += in.readLine(out); //""\r\n
-      assertEquals("line8 length, bufsz:"+bufsz, 0, out.getLength());
+      assertEquals(0, out.getLength(), "line8 length, bufsz:"+bufsz);
       c += in.readLine(out); //"eeeee"EOF
-      assertEquals("line9 length, bufsz:"+bufsz, 5, out.getLength());
-      assertEquals("end of file, bufsz: "+bufsz, 0, in.readLine(out));
-      assertEquals("total bytes, bufsz: "+bufsz, c, STRLENBYTES);
+      assertEquals(5, out.getLength(), "line9 length, bufsz:"+bufsz);
+      assertEquals(0, in.readLine(out), "end of file, bufsz: "+bufsz);
+      assertEquals(c, STRLENBYTES, "total bytes, bufsz: "+bufsz);
     }
   }
 
@@ -396,7 +402,8 @@ public class TestTextInputFormat {
    *
    * @throws Exception
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testMaxLineLength() throws Exception {
     final String STR = "a\nbb\n\nccc\rdddd\r\neeeee";
     final int STRLENBYTES = STR.getBytes().length;
@@ -405,23 +412,24 @@ public class TestTextInputFormat {
       LineReader in = makeStream(STR, bufsz);
       int c = 0;
       c += in.readLine(out, 1);
-      assertEquals("line1 length, bufsz: "+bufsz, 1, out.getLength());
+      assertEquals(1, out.getLength(), "line1 length, bufsz: "+bufsz);
       c += in.readLine(out, 1);
-      assertEquals("line2 length, bufsz: "+bufsz, 1, out.getLength());
+      assertEquals(1, out.getLength(), "line2 length, bufsz: "+bufsz);
       c += in.readLine(out, 1);
-      assertEquals("line3 length, bufsz: "+bufsz, 0, out.getLength());
+      assertEquals(0, out.getLength(), "line3 length, bufsz: "+bufsz);
       c += in.readLine(out, 3);
-      assertEquals("line4 length, bufsz: "+bufsz, 3, out.getLength());
+      assertEquals(3, out.getLength(), "line4 length, bufsz: "+bufsz);
       c += in.readLine(out, 10);
-      assertEquals("line5 length, bufsz: "+bufsz, 4, out.getLength());
+      assertEquals(4, out.getLength(), "line5 length, bufsz: "+bufsz);
       c += in.readLine(out, 8);
-      assertEquals("line5 length, bufsz: "+bufsz, 5, out.getLength());
-      assertEquals("end of file, bufsz: " +bufsz, 0, in.readLine(out));
-      assertEquals("total bytes, bufsz: "+bufsz, c, STRLENBYTES);
+      assertEquals(5, out.getLength(), "line5 length, bufsz: "+bufsz);
+      assertEquals(0, in.readLine(out), "end of file, bufsz: " +bufsz);
+      assertEquals(c, STRLENBYTES, "total bytes, bufsz: "+bufsz);
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testMRMaxLine() throws Exception {
     final int MAXPOS = 1024 * 1024;
     final int MAXLINE = 10 * 1024;
@@ -436,7 +444,7 @@ public class TestTextInputFormat {
       }
       @Override
       public int read(byte[] b) {
-        assertTrue("Read too many bytes from the stream", position < MAXPOSBUF);
+        assertTrue(position < MAXPOSBUF, "Read too many bytes from the stream");
         Arrays.fill(b, (byte) 0);
         position += b.length;
         return b.length;
@@ -454,10 +462,10 @@ public class TestTextInputFormat {
     conf.setInt("io.file.buffer.size", BUF); // used by LRR
     // test another constructor 
      LineRecordReader lrr = new LineRecordReader(infNull, 0, MAXPOS, conf);
-    assertFalse("Read a line from null", lrr.next(key, val));
+    assertFalse(lrr.next(key, val), "Read a line from null");
     infNull.reset();
      lrr = new LineRecordReader(infNull, 0L, MAXLINE, MAXPOS);
-    assertFalse("Read a line from null", lrr.next(key, val));
+    assertFalse(lrr.next(key, val), "Read a line from null");
     
     
   }
@@ -496,7 +504,8 @@ public class TestTextInputFormat {
   /**
    * Test using the gzip codec for reading
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testGzip() throws IOException {
     JobConf job = new JobConf(defaultConf);
     CompressionCodec gzip = new GzipCodec();
@@ -510,17 +519,17 @@ public class TestTextInputFormat {
     TextInputFormat format = new TextInputFormat();
     format.configure(job);
     InputSplit[] splits = format.getSplits(job, 100);
-    assertEquals("compressed splits == 2", 2, splits.length);
+    assertEquals(2, splits.length, "compressed splits == 2");
     FileSplit tmp = (FileSplit) splits[0];
     if (tmp.getPath().getName().equals("part2.txt.gz")) {
       splits[0] = splits[1];
       splits[1] = tmp;
     }
     List<Text> results = readSplit(format, splits[0], job);
-    assertEquals("splits[0] length", 6, results.size());
+    assertEquals(6, results.size(), "splits[0] length");
     assertEquals("splits[0][5]", " dog", results.get(5).toString());
     results = readSplit(format, splits[1], job);
-    assertEquals("splits[1] length", 2, results.size());
+    assertEquals(2, results.size(), "splits[1] length");
     assertEquals("splits[1][0]", "this is a test", 
                  results.get(0).toString());    
     assertEquals("splits[1][1]", "of gzip", 
@@ -530,7 +539,8 @@ public class TestTextInputFormat {
   /**
    * Test using the gzip codec and an empty input file
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5)
   public void testGzipEmpty() throws IOException {
     JobConf job = new JobConf(defaultConf);
     CompressionCodec gzip = new GzipCodec();
@@ -541,10 +551,10 @@ public class TestTextInputFormat {
     TextInputFormat format = new TextInputFormat();
     format.configure(job);
     InputSplit[] splits = format.getSplits(job, 100);
-    assertEquals("Compressed files of length 0 are not returned from FileInputFormat.getSplits().",
-                 1, splits.length);
+    assertEquals(
+                1, splits.length, "Compressed files of length 0 are not returned from FileInputFormat.getSplits().");
     List<Text> results = readSplit(format, splits[0], job);
-    assertEquals("Compressed empty file length == 0", 0, results.size());
+    assertEquals(0, results.size(), "Compressed empty file length == 0");
   }
   
   private static String unquote(String in) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestTextOutputFormat.java
@@ -22,10 +22,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestUserDefinedCounters.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestUserDefinedCounters.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,8 +35,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUserDefinedCounters {
   private static String TEST_ROOT_DIR =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestUtils.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapred;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestUtils {
   private static final Path[] LOG_PATHS = new Path[] {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestWritableJobConf.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestWritableJobConf.java
@@ -25,13 +25,13 @@ import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.io.serializer.Serializer;
 import org.apache.hadoop.util.GenericsUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestWritableJobConf {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestYARNRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/TestYARNRunner.java
@@ -20,11 +20,11 @@ package org.apache.hadoop.mapred;
 
 import static org.apache.hadoop.test.PlatformAssumptions.assumeNotWindows;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -117,11 +117,12 @@ import org.apache.log4j.Level;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -179,12 +180,12 @@ public class TestYARNRunner {
   private  ClientServiceDelegate clientDelegate;
   private static final String failString = "Rejected job";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBeforeClass() {
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     resourceMgrDelegate = mock(ResourceMgrDelegate.class);
     conf = new YarnConfiguration();
@@ -213,13 +214,14 @@ public class TestYARNRunner {
     testWorkDir.mkdirs();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(testWorkDir);
     ResourceUtils.resetResourceTypes(new Configuration());
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testJobKill() throws Exception {
     clientDelegate = mock(ClientServiceDelegate.class);
     when(clientDelegate.getJobStatus(any(JobID.class))).thenReturn(new
@@ -255,7 +257,8 @@ public class TestYARNRunner {
     verify(clientDelegate).killJob(jobId);
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testJobKillTimeout() throws Exception {
     long timeToWaitBeforeHardKill =
         10000 + MRJobConfig.DEFAULT_MR_AM_HARD_KILL_TIMEOUT_MS;
@@ -276,12 +279,13 @@ public class TestYARNRunner {
             State.RUNNING, JobPriority.HIGH, "tmp", "tmp", "tmp", "tmp"));
     long startTimeMillis = System.currentTimeMillis();
     yarnRunner.killJob(jobId);
-    assertTrue("killJob should have waited at least " + timeToWaitBeforeHardKill
-        + " ms.", System.currentTimeMillis() - startTimeMillis
-                  >= timeToWaitBeforeHardKill);
+    assertTrue(System.currentTimeMillis() - startTimeMillis
+                  >= timeToWaitBeforeHardKill, "killJob should have waited at least " + timeToWaitBeforeHardKill
+        + " ms.");
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testJobSubmissionFailure() throws Exception {
     when(resourceMgrDelegate.submitApplication(any(ApplicationSubmissionContext.class))).
     thenReturn(appId);
@@ -303,7 +307,8 @@ public class TestYARNRunner {
     }
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testResourceMgrDelegate() throws Exception {
     /* we not want a mock of resource mgr delegate */
     final ApplicationClientProtocol clientRMProtocol = mock(ApplicationClientProtocol.class);
@@ -371,7 +376,8 @@ public class TestYARNRunner {
     verify(clientRMProtocol).getQueueUserAcls(any(GetQueueUserAclsInfoRequest.class));
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testGetHSDelegationToken() throws Exception {
     try {
       Configuration conf = new Configuration();
@@ -452,7 +458,8 @@ public class TestYARNRunner {
     }
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testHistoryServerToken() throws Exception {
     //Set the master principal in the config
     conf.set(YarnConfiguration.RM_PRINCIPAL,"foo@LOCAL");
@@ -495,7 +502,8 @@ public class TestYARNRunner {
         });
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testAMAdminCommandOpts() throws Exception {
     JobConf jobConf = new JobConf();
     
@@ -519,8 +527,8 @@ public class TestYARNRunner {
 
     for(String command : commands) {
       if(command != null) {
-        assertFalse("Profiler should be disabled by default",
-            command.contains(PROFILE_PARAMS));
+        assertFalse(
+           command.contains(PROFILE_PARAMS), "Profiler should be disabled by default");
         adminPos = command.indexOf("-Djava.net.preferIPv4Stack=true");
         if(adminPos >= 0)
           adminIndex = index;
@@ -536,20 +544,21 @@ public class TestYARNRunner {
     }
 
     // Check java.io.tmpdir opts are set in the commands
-    assertTrue("java.io.tmpdir is not set for AM", tmpDirPos > 0);
+    assertTrue(tmpDirPos > 0, "java.io.tmpdir is not set for AM");
 
     // Check both admin java opts and user java opts are in the commands
-    assertTrue("AM admin command opts not in the commands.", adminPos > 0);
-    assertTrue("AM user command opts not in the commands.", userPos > 0);
+    assertTrue(adminPos > 0, "AM admin command opts not in the commands.");
+    assertTrue(userPos > 0, "AM user command opts not in the commands.");
     
     // Check the admin java opts is before user java opts in the commands
     if(adminIndex == userIndex) {
-      assertTrue("AM admin command opts is after user command opts.", adminPos < userPos);
+      assertTrue(adminPos < userPos, "AM admin command opts is after user command opts.");
     } else {
-      assertTrue("AM admin command opts is after user command opts.", adminIndex < userIndex);
+      assertTrue(adminIndex < userIndex, "AM admin command opts is after user command opts.");
     }
   }
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testWarnCommandOpts() throws Exception {
     org.apache.log4j.Logger logger =
         org.apache.log4j.Logger.getLogger(YARNRunner.class);
@@ -583,7 +592,8 @@ public class TestYARNRunner {
         "using yarn.app.mapreduce.am.env config settings."));
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20)
   public void testAMProfiler() throws Exception {
     JobConf jobConf = new JobConf();
 
@@ -837,7 +847,7 @@ public class TestYARNRunner {
     ContainerLaunchContext clc = appSubCtx.getAMContainerSpec();
     Map<String, String> env = clc.getEnvironment();
     String libPath = env.get(pathKey);
-    assertNotNull(pathKey + " not set", libPath);
+    assertNotNull(libPath, pathKey + " not set");
     String cps = jobConf.getBoolean(
         MRConfig.MAPREDUCE_APP_SUBMISSION_CROSS_PLATFORM,
         MRConfig.DEFAULT_MAPREDUCE_APP_SUBMISSION_CROSS_PLATFORM)
@@ -852,12 +862,12 @@ public class TestYARNRunner {
           MRJobConfig.DEFAULT_MR_AM_ADMIN_USER_ENV.substring(
               pathKey.length() + 1);
     }
-    assertEquals("Bad AM " + pathKey + " setting", expectedLibPath, libPath);
+    assertEquals(expectedLibPath, libPath, "Bad AM " + pathKey + " setting");
 
     // make sure SHELL is set
     String shell = env.get(Environment.SHELL.name());
-    assertNotNull("SHELL not set", shell);
-    assertEquals("Bad SHELL setting", USER_SHELL, shell);
+    assertNotNull(shell, "SHELL not set");
+    assertEquals(USER_SHELL, shell, "Bad SHELL setting");
   }
 
   @Test
@@ -929,13 +939,13 @@ public class TestYARNRunner {
     Configuration confSent = BuilderUtils.parseTokensConf(submissionContext);
 
     // configs that match regex should be included
-    Assert.assertEquals("123.0.0.1",
+    Assertions.assertEquals("123.0.0.1",
         confSent.get("dfs.namenode.rpc-address.mycluster2.nn1"));
-    Assert.assertEquals("123.0.0.2",
+    Assertions.assertEquals("123.0.0.2",
         confSent.get("dfs.namenode.rpc-address.mycluster2.nn2"));
 
     // configs that aren't matching regex should not be included
-    Assert.assertTrue(confSent.get("hadoop.tmp.dir") == null || !confSent
+    Assertions.assertTrue(confSent.get("hadoop.tmp.dir") == null || !confSent
         .get("hadoop.tmp.dir").equals("testconfdir"));
     UserGroupInformation.reset();
   }
@@ -957,15 +967,15 @@ public class TestYARNRunner {
     List<ResourceRequest> resourceRequests =
         submissionContext.getAMContainerResourceRequests();
 
-    Assert.assertEquals(1, resourceRequests.size());
+    Assertions.assertEquals(1, resourceRequests.size());
     ResourceRequest resourceRequest = resourceRequests.get(0);
 
     ResourceInformation resourceInformation = resourceRequest.getCapability()
         .getResourceInformation(CUSTOM_RESOURCE_NAME);
-    Assert.assertEquals("Expecting the default unit (G)",
+    Assertions.assertEquals("Expecting the default unit (G)",
         "G", resourceInformation.getUnits());
-    Assert.assertEquals(5L, resourceInformation.getValue());
-    Assert.assertEquals(3, resourceRequest.getCapability().getVirtualCores());
+    Assertions.assertEquals(5L, resourceInformation.getValue());
+    Assertions.assertEquals(3, resourceRequest.getCapability().getVirtualCores());
   }
 
   @Test
@@ -983,11 +993,11 @@ public class TestYARNRunner {
       List<ResourceRequest> resourceRequests =
           submissionContext.getAMContainerResourceRequests();
 
-      Assert.assertEquals(1, resourceRequests.size());
+      Assertions.assertEquals(1, resourceRequests.size());
       ResourceRequest resourceRequest = resourceRequests.get(0);
 
       long memorySize = resourceRequest.getCapability().getMemorySize();
-      Assert.assertEquals(3072, memorySize);
+      Assertions.assertEquals(3072, memorySize);
     }
   }
 
@@ -1012,11 +1022,11 @@ public class TestYARNRunner {
         List<ResourceRequest> resourceRequests =
             submissionContext.getAMContainerResourceRequests();
 
-        Assert.assertEquals(1, resourceRequests.size());
+        Assertions.assertEquals(1, resourceRequests.size());
         ResourceRequest resourceRequest = resourceRequests.get(0);
 
         long memorySize = resourceRequest.getCapability().getMemorySize();
-        Assert.assertEquals(3072, memorySize);
+        Assertions.assertEquals(3072, memorySize);
         assertTrue(testAppender.getLogEvents().stream().anyMatch(
             e -> e.getLevel() == Level.WARN && ("Configuration " +
                 "yarn.app.mapreduce.am.resource." + memoryName + "=3Gi is " +

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/TestJobControl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/TestJobControl.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -32,7 +32,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapreduce.lib.jobcontrol.ControlledJob;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class performs unit test for Job/JobControl classes.
@@ -198,14 +199,15 @@ public class TestJobControl {
   }
 
   @SuppressWarnings("deprecation")
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testJobState() throws Exception {
     Job job_1 = getCopyJob();
     JobControl jc = new JobControl("Test");
     jc.addJob(job_1);
-    Assert.assertEquals(Job.WAITING, job_1.getState());
+    Assertions.assertEquals(Job.WAITING, job_1.getState());
     job_1.setState(Job.SUCCESS);
-    Assert.assertEquals(Job.WAITING, job_1.getState());
+    Assertions.assertEquals(Job.WAITING, job_1.getState());
 
     org.apache.hadoop.mapreduce.Job mockjob =
         mock(org.apache.hadoop.mapreduce.Job.class);
@@ -213,20 +215,21 @@ public class TestJobControl {
         new org.apache.hadoop.mapreduce.JobID("test", 0);
     when(mockjob.getJobID()).thenReturn(jid);
     job_1.setJob(mockjob);
-    Assert.assertEquals("job_test_0000", job_1.getMapredJobID());
+    Assertions.assertEquals("job_test_0000", job_1.getMapredJobID());
     job_1.setMapredJobID("job_test_0001");
-    Assert.assertEquals("job_test_0000", job_1.getMapredJobID());
+    Assertions.assertEquals("job_test_0000", job_1.getMapredJobID());
     jc.stop();
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAddingDependingJob() throws Exception {
     Job job_1 = getCopyJob();
     ArrayList<Job> dependingJobs = new ArrayList<Job>();
     JobControl jc = new JobControl("Test");
     jc.addJob(job_1);
-    Assert.assertEquals(Job.WAITING, job_1.getState());
-    Assert.assertTrue(job_1.addDependingJob(new Job(job_1.getJobConf(),
+    Assertions.assertEquals(Job.WAITING, job_1.getState());
+    Assertions.assertTrue(job_1.addDependingJob(new Job(job_1.getJobConf(),
       dependingJobs)));
   }
 
@@ -253,23 +256,25 @@ public class TestJobControl {
     return job_1;
   }
   
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testJobControl() throws Exception {
     doJobControlTest();
   }
   
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testGetAssignedJobId() throws Exception {
     JobConf jc = new JobConf();
     Job j = new Job(jc);
     //Just make sure no exception is thrown
-    Assert.assertNull(j.getAssignedJobID());
+    Assertions.assertNull(j.getAssignedJobID());
     org.apache.hadoop.mapreduce.Job mockjob = mock(org.apache.hadoop.mapreduce.Job.class);
     org.apache.hadoop.mapreduce.JobID jid = new org.apache.hadoop.mapreduce.JobID("test",0);
     when(mockjob.getJobID()).thenReturn(jid);
     j.setJob(mockjob);
     JobID expected = new JobID("test",0);
-    Assert.assertEquals(expected, j.getAssignedJobID());
+    Assertions.assertEquals(expected, j.getAssignedJobID());
     verify(mockjob).getJobID();
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/TestLocalJobControl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/jobcontrol/TestLocalJobControl.java
@@ -25,11 +25,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * HadoopTestCase that tests the local job runner.
@@ -132,7 +132,7 @@ public class TestLocalJobControl extends HadoopTestCase {
       }
     }
 
-    assertEquals("Some jobs failed", 0, theControl.getFailedJobs().size());
+    assertEquals(0, theControl.getFailedJobs().size(), "Some jobs failed");
     theControl.stop();
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestDatamerge.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestDatamerge.java
@@ -49,23 +49,22 @@ import org.apache.hadoop.mapred.Utils;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDatamerge {
 
   private static MiniDFSCluster cluster = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Configuration conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
   }
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -131,7 +130,7 @@ public class TestDatamerge {
     public void close() { }
     public void configure(JobConf job) {
       srcs = job.getInt("testdatamerge.sources", 0);
-      assertTrue("Invalid src count: " + srcs, srcs > 0);
+      assertTrue(srcs > 0, "Invalid src count: " + srcs);
     }
     public abstract void map(IntWritable key, V val,
         OutputCollector<IntWritable, IntWritable> out, Reporter reporter)
@@ -143,7 +142,7 @@ public class TestDatamerge {
       while (values.hasNext()) {
         seen += values.next().get();
       }
-      assertTrue("Bad count for " + key.get(), verify(key.get(), seen));
+      assertTrue(verify(key.get(), seen), "Bad count for " + key.get());
     }
     public abstract boolean verify(int key, int occ);
   }
@@ -155,10 +154,10 @@ public class TestDatamerge {
         throws IOException {
       int k = key.get();
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
-      assertTrue(kvstr, 0 == k % (srcs * srcs));
+      assertEquals(0, k % (srcs * srcs), kvstr);
       for (int i = 0; i < val.size(); ++i) {
         final int vali = ((IntWritable)val.get(i)).get();
-        assertTrue(kvstr, (vali - i) * srcs == 10 * k);
+        assertEquals((vali - i) * srcs, 10 * k, kvstr);
       }
       out.collect(key, one);
     }
@@ -177,18 +176,18 @@ public class TestDatamerge {
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
       if (0 == k % (srcs * srcs)) {
         for (int i = 0; i < val.size(); ++i) {
-          assertTrue(kvstr, val.get(i) instanceof IntWritable);
+          assertInstanceOf(IntWritable.class, val.get(i), kvstr);
           final int vali = ((IntWritable)val.get(i)).get();
-          assertTrue(kvstr, (vali - i) * srcs == 10 * k);
+          assertEquals((vali - i) * srcs, 10 * k, kvstr);
         }
       } else {
         for (int i = 0; i < val.size(); ++i) {
           if (i == k % srcs) {
-            assertTrue(kvstr, val.get(i) instanceof IntWritable);
+            assertInstanceOf(IntWritable.class, val.get(i), kvstr);
             final int vali = ((IntWritable)val.get(i)).get();
-            assertTrue(kvstr, srcs * (vali - i) == 10 * (k - i));
+            assertEquals(srcs * (vali - i), 10 * (k - i), kvstr);
           } else {
-            assertTrue(kvstr, !val.has(i));
+            assertFalse(val.has(i), kvstr);
           }
         }
       }
@@ -210,10 +209,10 @@ public class TestDatamerge {
       final int vali = val.get();
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
       if (0 == k % (srcs * srcs)) {
-        assertTrue(kvstr, vali == k * 10 / srcs + srcs - 1);
+        assertEquals(vali, k * 10 / srcs + srcs - 1, kvstr);
       } else {
         final int i = k % srcs;
-        assertTrue(kvstr, srcs * (vali - i) == 10 * (k - i));
+        assertEquals(srcs * (vali - i), 10 * (k - i), kvstr);
       }
       out.collect(key, one);
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestTupleWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestTupleWritable.java
@@ -34,10 +34,10 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestTupleWritable {
 
@@ -97,7 +97,7 @@ public class TestTupleWritable {
         i = verifIter(writs, ((TupleWritable)w), i);
         continue;
       }
-      assertTrue("Bad value", w.equals(writs[i++]));
+      assertEquals(w, writs[i++], "Bad value");
     }
     return i;
   }
@@ -140,7 +140,7 @@ public class TestTupleWritable {
       new IntWritable(r.nextInt())
     };
     TupleWritable sTuple = makeTuple(writs);
-    assertTrue("Bad count", writs.length == verifIter(writs, sTuple, 0));
+    assertEquals(writs.length, verifIter(writs, sTuple, 0), "Bad count");
   }
 
   @Test
@@ -164,7 +164,7 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Failed to write/read tuple", sTuple.equals(dTuple));
+    assertEquals(sTuple, dTuple, "Failed to write/read tuple");
   }
 
   @Test
@@ -183,8 +183,8 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Failed to write/read tuple", sTuple.equals(dTuple));
-    assertEquals("All tuple data has not been read from the stream",-1,in.read());
+    assertEquals(sTuple, dTuple, "Failed to write/read tuple");
+    assertEquals(-1, in.read(), "All tuple data has not been read from the stream");
   }
 
   @Test
@@ -201,8 +201,8 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Failed to write/read tuple", sTuple.equals(dTuple));
-    assertEquals("All tuple data has not been read from the stream",-1,in.read());
+    assertEquals(sTuple, dTuple, "Failed to write/read tuple");
+    assertEquals(-1, in.read(), "All tuple data has not been read from the stream");
   }
   
   /**
@@ -225,8 +225,8 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Failed to write/read tuple", sTuple.equals(dTuple));
-    assertEquals("All tuple data has not been read from the stream",-1,in.read());
+    assertEquals(sTuple, dTuple, "Failed to write/read tuple");
+    assertEquals(-1, in.read(), "All tuple data has not been read from the stream");
   }
   @Test
   public void testWideTuple() throws Exception {
@@ -244,7 +244,7 @@ public class TestTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos, has);
+        assertFalse(has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }
@@ -264,7 +264,7 @@ public class TestTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos, has);
+        assertFalse(has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }
@@ -288,7 +288,7 @@ public class TestTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos, has);
+        assertFalse(has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }
@@ -311,8 +311,8 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Tuple writable is unable to read pre-0.21 versions of TupleWritable", oldTuple.isCompatible(dTuple));
-    assertEquals("All tuple data has not been read from the stream",-1,in.read());
+    assertTrue(oldTuple.isCompatible(dTuple), "Tuple writable is unable to read pre-0.21 versions of TupleWritable");
+    assertEquals(-1, in.read(), "All tuple data has not been read from the stream");
   }
   @Test
   public void testPreVersion21CompatibilityEmptyTuple() throws Exception {
@@ -324,8 +324,8 @@ public class TestTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Tuple writable is unable to read pre-0.21 versions of TupleWritable", oldTuple.isCompatible(dTuple));
-    assertEquals("All tuple data has not been read from the stream",-1,in.read());
+    assertTrue(oldTuple.isCompatible(dTuple), "Tuple writable is unable to read pre-0.21 versions of TupleWritable");
+    assertEquals(-1, in.read(), "All tuple data has not been read from the stream");
   }
   
   /**
@@ -335,7 +335,7 @@ public class TestTupleWritable {
   private static class PreVersion21TupleWritable {
     
     private Writable[] values;
-    private long written = 0L;
+    private long written;
 
     private PreVersion21TupleWritable(Writable[] vals) {
       written = 0L;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestWrappedRecordReaderClassloader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/join/TestWrappedRecordReaderClassloader.java
@@ -33,8 +33,10 @@ import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestWrappedRecordReaderClassloader {
   /**
@@ -47,7 +49,7 @@ public class TestWrappedRecordReaderClassloader {
     JobConf job = new JobConf();
     Fake_ClassLoader classLoader = new Fake_ClassLoader();
     job.setClassLoader(classLoader);
-    assertTrue(job.getClassLoader() instanceof Fake_ClassLoader);
+    assertInstanceOf(Fake_ClassLoader.class, job.getClassLoader());
 
     FileSystem fs = FileSystem.get(job);
     Path testdir = fs.makeQualified(new Path(
@@ -58,7 +60,7 @@ public class TestWrappedRecordReaderClassloader {
     job.set("mapreduce.join.expr", CompositeInputFormat.compose("outer",
         IF_ClassLoaderChecker.class, src));
 
-    CompositeInputFormat<NullWritable> inputFormat = new CompositeInputFormat<NullWritable>();
+    CompositeInputFormat<NullWritable> inputFormat = new CompositeInputFormat<>();
     inputFormat.getRecordReader(inputFormat.getSplits(job, 1)[0], job,
         Reporter.NULL);
   }
@@ -113,7 +115,7 @@ public class TestWrappedRecordReaderClassloader {
 
     public RecordReader<K, V> getRecordReader(InputSplit ignored, JobConf job,
         Reporter reporter) {
-      return new RR_ClassLoaderChecker<K, V>(job);
+      return new RR_ClassLoaderChecker<>(job);
     }
   }
 
@@ -123,9 +125,9 @@ public class TestWrappedRecordReaderClassloader {
 
     @SuppressWarnings("unchecked")
     public RR_ClassLoaderChecker(JobConf job) {
-      assertTrue("The class loader has not been inherited from "
-          + CompositeRecordReader.class.getSimpleName(),
-          job.getClassLoader() instanceof Fake_ClassLoader);
+      assertInstanceOf(Fake_ClassLoader.class, job.getClassLoader(),
+         "The class loader has not been inherited from " +
+          CompositeRecordReader.class.getSimpleName());
 
       keyclass = (Class<? extends K>) job.getClass("test.fakeif.keyclass",
           NullWritable.class, WritableComparable.class);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestChain.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestChain.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.mapred.lib;
 
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestChainMapReduce.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestChainMapReduce.java
@@ -33,16 +33,16 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestChainMapReduce extends HadoopTestCase {
 
@@ -108,7 +108,7 @@ public class TestChainMapReduce extends HadoopTestCase {
 
     fs.delete(outDir, true);
     if (!fs.mkdirs(inDir)) {
-      throw new IOException("Mkdirs failed to create " + inDir.toString());
+      throw new IOException("Mkdirs failed to create " + inDir);
     }
 
     DataOutputStream file = fs.create(new Path(inDir, "part-0"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestDelegatingInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestDelegatingInputFormat.java
@@ -30,9 +30,9 @@ import org.apache.hadoop.mapred.Mapper;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDelegatingInputFormat {
   @Test
@@ -66,7 +66,7 @@ public class TestDelegatingInputFormat {
 
       int[] bins = new int[3];
       for (InputSplit split : splits) {
-       assertTrue(split instanceof TaggedInputSplit);
+       assertInstanceOf(TaggedInputSplit.class, split);
        final TaggedInputSplit tis = (TaggedInputSplit) split;
        int index = -1;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestKeyFieldBasedComparator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestKeyFieldBasedComparator.java
@@ -34,10 +34,10 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
 import org.apache.hadoop.mapred.Utils;
-import org.junit.After;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -89,10 +89,10 @@ public class TestKeyFieldBasedComparator extends HadoopTestCase {
     conf.setMapperClass(InverseMapper.class);
     conf.setReducerClass(IdentityReducer.class);
     if (!fs.mkdirs(testdir)) {
-      throw new IOException("Mkdirs failed to create " + testdir.toString());
+      throw new IOException("Mkdirs failed to create " + testdir);
     }
     if (!fs.mkdirs(inDir)) {
-      throw new IOException("Mkdirs failed to create " + inDir.toString());
+      throw new IOException("Mkdirs failed to create " + inDir);
     }
     // set up input data in 2 files 
     Path inFile = new Path(inDir, "part0");
@@ -133,7 +133,7 @@ public class TestKeyFieldBasedComparator extends HadoopTestCase {
     }
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_DIR);
   }
@@ -161,7 +161,7 @@ public class TestKeyFieldBasedComparator extends HadoopTestCase {
   byte[] line2_bytes = line2.getBytes();
 
   public void localTestWithoutMRJob(String keySpec, int expect) throws Exception {
-    KeyFieldBasedComparator<Void, Void> keyFieldCmp = new KeyFieldBasedComparator<Void, Void>();
+    KeyFieldBasedComparator<Void, Void> keyFieldCmp = new KeyFieldBasedComparator<>();
     localConf.setKeyFieldComparatorOptions(keySpec);
     keyFieldCmp.configure(localConf);
     int result = keyFieldCmp.compare(line1_bytes, 0, line1_bytes.length,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestKeyFieldBasedPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestKeyFieldBasedPartitioner.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.mapred.lib;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestKeyFieldBasedPartitioner {
 
@@ -31,18 +31,16 @@ public class TestKeyFieldBasedPartitioner {
   @Test
   public void testEmptyKey() throws Exception {
     KeyFieldBasedPartitioner<Text, Text> kfbp = 
-      new KeyFieldBasedPartitioner<Text, Text>();
+      new KeyFieldBasedPartitioner<>();
     JobConf conf = new JobConf();
     conf.setInt("num.key.fields.for.partition", 10);
     kfbp.configure(conf);
-    assertEquals("Empty key should map to 0th partition", 
-                 0, kfbp.getPartition(new Text(), new Text(), 10));
+    assertEquals(0, kfbp.getPartition(new Text(), new Text(), 10), "Empty key should map to 0th partition");
   }
 
   @Test
   public void testMultiConfigure() {
-    KeyFieldBasedPartitioner<Text, Text> kfbp =
-      new KeyFieldBasedPartitioner<Text, Text>();
+    KeyFieldBasedPartitioner<Text, Text> kfbp = new KeyFieldBasedPartitioner<>();
     JobConf conf = new JobConf();
     conf.set(KeyFieldBasedPartitioner.PARTITIONER_OPTIONS, "-k1,1");
     kfbp.setConf(conf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestLineInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestLineInputFormat.java
@@ -24,8 +24,8 @@ import java.util.*;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapred.*;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestLineInputFormat {
   private static int MAX_LENGTH = 200;
@@ -84,21 +84,21 @@ public class TestLineInputFormat {
     InputSplit[] splits = format.getSplits(job, ignoredNumSplits);
 
     // check all splits except last one
-    int count = 0;
+    int count;
     for (int j = 0; j < splits.length -1; j++) {
-      assertEquals("There are no split locations", 0,
-                   splits[j].getLocations().length);
+      assertEquals(0
+,         splits[j].getLocations().length, "There are no split locations");
       RecordReader<LongWritable, Text> reader =
         format.getRecordReader(splits[j], job, voidReporter);
       Class readerClass = reader.getClass();
-      assertEquals("reader class is LineRecordReader.",
-                   LineRecordReader.class, readerClass);        
+      assertEquals(
+          LineRecordReader.class, readerClass, "reader class is LineRecordReader.");
       LongWritable key = reader.createKey();
       Class keyClass = key.getClass();
-      assertEquals("Key class is LongWritable.", LongWritable.class, keyClass);
+      assertEquals(LongWritable.class, keyClass, "Key class is LongWritable.");
       Text value = reader.createValue();
       Class valueClass = value.getClass();
-      assertEquals("Value class is Text.", Text.class, valueClass);
+      assertEquals(Text.class, valueClass, "Value class is Text.");
          
       try {
         count = 0;
@@ -108,8 +108,8 @@ public class TestLineInputFormat {
       } finally {
         reader.close();
       }
-      assertEquals("number of lines in split is " + expectedN ,
-                   expectedN, count);
+      assertEquals( 
+                  expectedN, count, "number of lines in split is " + expectedN);
     }
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultipleInputs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultipleInputs.java
@@ -25,12 +25,12 @@ import org.apache.hadoop.mapred.Mapper;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.TextInputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @see TestDelegatingInputFormat

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultipleOutputs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultipleOutputs.java
@@ -39,9 +39,9 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -51,9 +51,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -77,16 +75,18 @@ public class TestMultipleOutputs extends HadoopTestCase {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(expected = IOException.class)
+  @Test
   public void testParallelCloseIOException() throws IOException {
-    RecordWriter writer = mock(RecordWriter.class);
-    Map<String, RecordWriter> recordWriters = mock(Map.class);
-    when(recordWriters.values()).thenReturn(Arrays.asList(writer, writer));
-    doThrow(new IOException("test IO exception")).when(writer).close(null);
-    JobConf conf = createJobConf();
-    MultipleOutputs mos = new MultipleOutputs(conf);
-    mos.setRecordWriters(recordWriters);
-    mos.close();
+    assertThrows(IOException.class, () -> {
+      RecordWriter writer = mock(RecordWriter.class);
+      Map<String, RecordWriter> recordWriters = mock(Map.class);
+      when(recordWriters.values()).thenReturn(Arrays.asList(writer, writer));
+      doThrow(new IOException("test IO exception")).when(writer).close(null);
+      JobConf conf = createJobConf();
+      MultipleOutputs mos = new MultipleOutputs(conf);
+      mos.setRecordWriters(recordWriters);
+      mos.close();
+    });
   }
 
   private static final Path ROOT_DIR = new Path("testing/mo");
@@ -103,7 +103,7 @@ public class TestMultipleOutputs extends HadoopTestCase {
     return dir;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     Path rootDir = getDir(ROOT_DIR);
@@ -117,7 +117,7 @@ public class TestMultipleOutputs extends HadoopTestCase {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     Path rootDir = getDir(ROOT_DIR);
 
@@ -202,7 +202,7 @@ public class TestMultipleOutputs extends HadoopTestCase {
       count++;
     }
     reader.close();
-    assertFalse(count == 0);
+    assertNotEquals(0, count);
 
     Counters.Group counters =
       job.getCounters().getGroup(MultipleOutputs.class.getName());
@@ -290,7 +290,7 @@ public class TestMultipleOutputs extends HadoopTestCase {
       count++;
     }
     reader.close();
-    assertFalse(count == 0);
+    assertNotEquals(0, count);
 
     // assert SequenceOutputFormat files correctness
     SequenceFile.Reader seqReader =
@@ -308,7 +308,7 @@ public class TestMultipleOutputs extends HadoopTestCase {
       count++;
     }
     seqReader.close();
-    assertFalse(count == 0);
+    assertNotEquals(0, count);
 
     Counters.Group counters =
       job.getCounters().getGroup(MultipleOutputs.class.getName());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultithreadedMapRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/TestMultithreadedMapRunner.java
@@ -35,14 +35,14 @@ import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
 import org.apache.hadoop.mapreduce.lib.map.MultithreadedMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMultithreadedMapRunner extends HadoopTestCase {
 
@@ -83,7 +83,7 @@ public class TestMultithreadedMapRunner extends HadoopTestCase {
 
     fs.delete(outDir, true);
     if (!fs.mkdirs(inDir)) {
-      throw new IOException("Mkdirs failed to create " + inDir.toString());
+      throw new IOException("Mkdirs failed to create " + inDir);
     }
     {
       DataOutputStream file = fs.create(new Path(inDir, "part-0"));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/aggregate/TestAggregates.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/aggregate/TestAggregates.java
@@ -20,14 +20,11 @@ package org.apache.hadoop.mapred.lib.aggregate;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
 import org.apache.hadoop.mapred.*;
-import org.apache.hadoop.mapred.lib.*;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
 import java.text.NumberFormat;
 
 public class TestAggregates {
@@ -81,7 +78,7 @@ public class TestAggregates {
     fileOut.close();
 
     System.out.println("inputData:");
-    System.out.println(inputData.toString());
+    System.out.println(inputData);
     JobConf job = new JobConf(conf, TestAggregates.class);
     FileInputFormat.setInputPaths(job, INPUT_DIR);
     job.setInputFormat(TextInputFormat.class);
@@ -114,7 +111,7 @@ public class TestAggregates {
     Path outPath = new Path(OUTPUT_DIR, "part-00000");
     String outdata = MapReduceTestUtil.readOutput(outPath,job);
     System.out.println("full out data:");
-    System.out.println(outdata.toString());
+    System.out.println(outdata);
     outdata = outdata.substring(0, expectedOutput.toString().length());
 
     assertEquals(expectedOutput.toString(),outdata);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/db/TestConstructQuery.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/lib/db/TestConstructQuery.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestConstructQuery {
   private String[] fieldNames = new String[] { "id", "name", "value" };
@@ -31,8 +31,7 @@ public class TestConstructQuery {
   private String expected = "INSERT INTO hadoop_output (id,name,value) VALUES (?,?,?);";
   private String nullExpected = "INSERT INTO hadoop_output VALUES (?,?,?);"; 
   
-  private DBOutputFormat<DBWritable, NullWritable> format 
-    = new DBOutputFormat<DBWritable, NullWritable>();
+  private DBOutputFormat<DBWritable, NullWritable> format = new DBOutputFormat<>();
   @Test
   public void testConstructQuery() {
     String actual = format.constructQuery("hadoop_output", fieldNames);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipeApplication.java
@@ -68,10 +68,10 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPipeApplication {
   private static File workSpace = new File("target",
@@ -82,7 +82,7 @@ public class TestPipeApplication {
   /**
    * test PipesMapRunner    test the transfer data from reader
    *
-   * @throws Exception
+   * @throws Exception The exception thrown during unit testing.
    */
   @Test
   public void testRunner() throws Exception {
@@ -97,26 +97,25 @@ public class TestPipeApplication {
 
       conf.set(MRJobConfig.TASK_ATTEMPT_ID, taskName);
 
-      CombineOutputCollector<IntWritable, Text> output = new CombineOutputCollector<IntWritable, Text>(
-              new Counters.Counter(), new Progress());
+      CombineOutputCollector<IntWritable, Text> output = new CombineOutputCollector<>(
+          new Counters.Counter(), new Progress());
       FileSystem fs = new RawLocalFileSystem();
       fs.initialize(FsConstants.LOCAL_FS_URI, conf);
-      Writer<IntWritable, Text> wr = new Writer<IntWritable, Text>(conf, fs.create(
-              new Path(workSpace + File.separator + "outfile")), IntWritable.class,
-              Text.class, null, null, true);
+      Writer<IntWritable, Text> wr = new Writer<>(conf, fs.create(
+          new Path(workSpace + File.separator + "outfile")), IntWritable.class,
+          Text.class, null, null, true);
       output.setWriter(wr);
       // stub for client
       File fCommand = getFileCommand("org.apache.hadoop.mapred.pipes.PipeApplicationRunnableStub");
 
       conf.set(MRJobConfig.CACHE_LOCALFILES, fCommand.getAbsolutePath());
       // token for authorization
-      Token<AMRMTokenIdentifier> token = new Token<AMRMTokenIdentifier>(
-              "user".getBytes(), "password".getBytes(), new Text("kind"), new Text(
-              "service"));
+      Token<AMRMTokenIdentifier> token = new Token<>(
+          "user".getBytes(), "password".getBytes(), new Text("kind"), new Text("service"));
       TokenCache.setJobToken(token,  conf.getCredentials());
       conf.setBoolean(MRJobConfig.SKIP_RECORDS, true);
       TestTaskReporter reporter = new TestTaskReporter();
-      PipesMapRunner<FloatWritable, NullWritable, IntWritable, Text> runner = new PipesMapRunner<FloatWritable, NullWritable, IntWritable, Text>();
+      PipesMapRunner<FloatWritable, NullWritable, IntWritable, Text> runner = new PipesMapRunner<>();
 
       initStdOut(conf);
 
@@ -153,7 +152,7 @@ public class TestPipeApplication {
    * test org.apache.hadoop.mapred.pipes.Application
    * test a internal functions: MessageType.REGISTER_COUNTER,  INCREMENT_COUNTER, STATUS, PROGRESS...
    *
-   * @throws Throwable
+   * @throws Throwable The exception thrown during unit testing.
    */
 
   @Test
@@ -174,16 +173,15 @@ public class TestPipeApplication {
       conf.set(MRJobConfig.CACHE_LOCALFILES, fCommand.getAbsolutePath());
 
       // token for authorization
-      Token<AMRMTokenIdentifier> token = new Token<AMRMTokenIdentifier>(
-              "user".getBytes(), "password".getBytes(), new Text("kind"), new Text(
-              "service"));
+      Token<AMRMTokenIdentifier> token = new Token<>(
+          "user".getBytes(), "password".getBytes(), new Text("kind"), new Text("service"));
 
       TokenCache.setJobToken(token, conf.getCredentials());
       FakeCollector output = new FakeCollector(new Counters.Counter(),
               new Progress());
       FileSystem fs = new RawLocalFileSystem();
       fs.initialize(FsConstants.LOCAL_FS_URI, conf);
-      Writer<IntWritable, Text> wr = new Writer<IntWritable, Text>(conf, fs.create(
+      Writer<IntWritable, Text> wr = new Writer<>(conf, fs.create(
               new Path(workSpace.getAbsolutePath() + File.separator + "outfile")),
               IntWritable.class, Text.class, null, null, true);
       output.setWriter(wr);
@@ -191,8 +189,8 @@ public class TestPipeApplication {
 
       initStdOut(conf);
 
-      Application<WritableComparable<IntWritable>, Writable, IntWritable, Text> application = new Application<WritableComparable<IntWritable>, Writable, IntWritable, Text>(
-              conf, rReader, output, reporter, IntWritable.class, Text.class);
+      Application<WritableComparable<IntWritable>, Writable, IntWritable, Text> application = new Application<>(
+          conf, rReader, output, reporter, IntWritable.class, Text.class);
       application.getDownlink().flush();
 
       application.getDownlink().mapItem(new IntWritable(3), new Text("txt"));
@@ -245,7 +243,7 @@ public class TestPipeApplication {
   /**
    * test org.apache.hadoop.mapred.pipes.Submitter
    *
-   * @throws Exception
+   * @throws Exception The exception thrown during unit testing.
    */
   @Test
   public void testSubmitter() throws Exception {
@@ -264,7 +262,7 @@ public class TestPipeApplication {
     Submitter.setKeepCommandFile(conf, false);
     Submitter.setIsJavaRecordReader(conf, false);
     Submitter.setIsJavaRecordWriter(conf, false);
-    PipesPartitioner<IntWritable, Text> partitioner = new PipesPartitioner<IntWritable, Text>();
+    PipesPartitioner<IntWritable, Text> partitioner = new PipesPartitioner<>();
     partitioner.configure(conf);
 
     Submitter.setJavaPartitioner(conf, partitioner.getClass());
@@ -284,7 +282,7 @@ public class TestPipeApplication {
     } catch (ExitUtil.ExitException e) {
       // System.exit prohibited! output message test
       assertTrue(out.toString().contains(""));
-      assertTrue(out.toString(), out.toString().contains("pipes"));
+      assertTrue(out.toString().contains("pipes"), out.toString());
       assertTrue(out.toString().contains("[-input <path>] // Input directory"));
       assertTrue(out.toString()
               .contains("[-output <path>] // Output directory"));
@@ -343,7 +341,7 @@ public class TestPipeApplication {
       String[] args = new String[22];
       File input = new File(workSpace + File.separator + "input");
       if (!input.exists()) {
-        Assert.assertTrue(input.createNewFile());
+        Assertions.assertTrue(input.createNewFile());
       }
       File outPut = new File(workSpace + File.separator + "output");
       FileUtil.fullyDelete(outPut);
@@ -388,7 +386,7 @@ public class TestPipeApplication {
    * test org.apache.hadoop.mapred.pipes.PipesReducer
    * test the transfer of data: key and value
    *
-   * @throws Exception
+   * @throws Exception The exception thrown during unit testing.
    */
   @Test
   public void testPipesReduser() throws Exception {
@@ -396,25 +394,24 @@ public class TestPipeApplication {
     File[] psw = cleanTokenPasswordFile();
     JobConf conf = new JobConf();
     try {
-      Token<AMRMTokenIdentifier> token = new Token<AMRMTokenIdentifier>(
-              "user".getBytes(), "password".getBytes(), new Text("kind"), new Text(
-              "service"));
+      Token<AMRMTokenIdentifier> token = new Token<>(
+          "user".getBytes(), "password".getBytes(), new Text("kind"), new Text("service"));
       TokenCache.setJobToken(token, conf.getCredentials());
 
       File fCommand = getFileCommand("org.apache.hadoop.mapred.pipes.PipeReducerStub");
       conf.set(MRJobConfig.CACHE_LOCALFILES, fCommand.getAbsolutePath());
 
-      PipesReducer<BooleanWritable, Text, IntWritable, Text> reducer = new PipesReducer<BooleanWritable, Text, IntWritable, Text>();
+      PipesReducer<BooleanWritable, Text, IntWritable, Text> reducer = new PipesReducer<>();
       reducer.configure(conf);
       BooleanWritable bw = new BooleanWritable(true);
 
       conf.set(MRJobConfig.TASK_ATTEMPT_ID, taskName);
       initStdOut(conf);
       conf.setBoolean(MRJobConfig.SKIP_RECORDS, true);
-      CombineOutputCollector<IntWritable, Text> output = new CombineOutputCollector<IntWritable, Text>(
-              new Counters.Counter(), new Progress());
+      CombineOutputCollector<IntWritable, Text> output = new CombineOutputCollector<>(
+          new Counters.Counter(), new Progress());
       Reporter reporter = new TestTaskReporter();
-      List<Text> texts = new ArrayList<Text>();
+      List<Text> texts = new ArrayList<>();
       texts.add(new Text("first"));
       texts.add(new Text("second"));
       texts.add(new Text("third"));
@@ -447,7 +444,7 @@ public class TestPipeApplication {
   @Test
   public void testPipesPartitioner() {
 
-    PipesPartitioner<IntWritable, Text> partitioner = new PipesPartitioner<IntWritable, Text>();
+    PipesPartitioner<IntWritable, Text> partitioner = new PipesPartitioner<>();
     JobConf configuration = new JobConf();
     Submitter.getJavaPartitioner(configuration);
     partitioner.configure(new JobConf());
@@ -569,7 +566,7 @@ public class TestPipeApplication {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     InputStream is = new FileInputStream(file);
     byte[] buffer = new byte[1024];
-    int counter = 0;
+    int counter;
     while ((counter = is.read(buffer)) >= 0) {
       out.write(buffer, 0, counter);
     }
@@ -813,7 +810,7 @@ public class TestPipeApplication {
   private class FakeCollector extends
           CombineOutputCollector<IntWritable, Text> {
 
-    final private Map<IntWritable, Text> collect = new HashMap<IntWritable, Text>();
+    final private Map<IntWritable, Text> collect = new HashMap<>();
 
     public FakeCollector(Counter outCounter, Progressable progressable) {
       super(outCounter, progressable);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipesNonJavaInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapred/pipes/TestPipesNonJavaInputFormat.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.pipes.TestPipeApplication.FakeSplit;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 
@@ -57,16 +57,16 @@ public class TestPipesNonJavaInputFormat {
     // input and output files
     File input1 = new File(workSpace + File.separator + "input1");
     if (!input1.getParentFile().exists()) {
-      Assert.assertTrue(input1.getParentFile().mkdirs());
+      Assertions.assertTrue(input1.getParentFile().mkdirs());
     }
 
     if (!input1.exists()) {
-      Assert.assertTrue(input1.createNewFile());
+      Assertions.assertTrue(input1.createNewFile());
     }
 
     File input2 = new File(workSpace + File.separator + "input2");
     if (!input2.exists()) {
-      Assert.assertTrue(input2.createNewFile());
+      Assertions.assertTrue(input2.createNewFile());
     }
     // set data for splits
     conf.set(org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR,

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestChild.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestChild.java
@@ -30,13 +30,13 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestChild extends HadoopTestCase {
   private static String TEST_ROOT_DIR =
@@ -63,25 +63,25 @@ public class TestChild extends HadoopTestCase {
       boolean oldConfigs = conf.getBoolean(OLD_CONFIGS, false);
       if (oldConfigs) {
         String javaOpts = conf.get(JobConf.MAPRED_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_TASK_JAVA_OPTS + " is null!", 
-                      javaOpts);
-        assertEquals(JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: " + 
-                     javaOpts, 
-                     javaOpts, TASK_OPTS_VAL);
+        assertNotNull(
+                      javaOpts, JobConf.MAPRED_TASK_JAVA_OPTS + " is null!");
+        assertEquals(
+                     javaOpts, TASK_OPTS_VAL, JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: " + 
+                     javaOpts);
       } else {
         String mapJavaOpts = conf.get(JobConf.MAPRED_MAP_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " is null!", 
-                      mapJavaOpts);
-        assertEquals(JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " has value of: " + 
-                     mapJavaOpts, 
-                     mapJavaOpts, MAP_OPTS_VAL);
+        assertNotNull(
+                      mapJavaOpts, JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " is null!");
+        assertEquals(
+                     mapJavaOpts, MAP_OPTS_VAL, JobConf.MAPRED_MAP_TASK_JAVA_OPTS + " has value of: " + 
+                     mapJavaOpts);
       }
       
       Level logLevel = 
         Level.toLevel(conf.get(JobConf.MAPRED_MAP_TASK_LOG_LEVEL, 
                                Level.INFO.toString()));  
-      assertEquals(JobConf.MAPRED_MAP_TASK_LOG_LEVEL + "has value of " + 
-                   logLevel, logLevel, Level.OFF);
+      assertEquals(logLevel, Level.OFF, JobConf.MAPRED_MAP_TASK_LOG_LEVEL + "has value of " + 
+                   logLevel);
     }
   }
   
@@ -95,25 +95,25 @@ public class TestChild extends HadoopTestCase {
       boolean oldConfigs = conf.getBoolean(OLD_CONFIGS, false);
       if (oldConfigs) {
         String javaOpts = conf.get(JobConf.MAPRED_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_TASK_JAVA_OPTS + " is null!", 
-                      javaOpts);
-        assertEquals(JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: " + 
-                     javaOpts, 
-                     javaOpts, TASK_OPTS_VAL);
+        assertNotNull(
+                      javaOpts, JobConf.MAPRED_TASK_JAVA_OPTS + " is null!");
+        assertEquals(
+                     javaOpts, TASK_OPTS_VAL, JobConf.MAPRED_TASK_JAVA_OPTS + " has value of: " + 
+                     javaOpts);
       } else {
         String reduceJavaOpts = conf.get(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS);
-        assertNotNull(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " is null!", 
-                      reduceJavaOpts);
-        assertEquals(JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " has value of: " + 
-                     reduceJavaOpts, 
-                     reduceJavaOpts, REDUCE_OPTS_VAL);
+        assertNotNull(
+                      reduceJavaOpts, JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " is null!");
+        assertEquals(
+                     reduceJavaOpts, REDUCE_OPTS_VAL, JobConf.MAPRED_REDUCE_TASK_JAVA_OPTS + " has value of: " + 
+                     reduceJavaOpts);
       }
       
       Level logLevel = 
         Level.toLevel(conf.get(JobConf.MAPRED_REDUCE_TASK_LOG_LEVEL, 
                                Level.INFO.toString()));  
-      assertEquals(JobConf.MAPRED_REDUCE_TASK_LOG_LEVEL + "has value of " + 
-                   logLevel, logLevel, Level.OFF);
+      assertEquals(logLevel, Level.OFF, JobConf.MAPRED_REDUCE_TASK_LOG_LEVEL + "has value of " + 
+                   logLevel);
     }
   }
   
@@ -135,21 +135,21 @@ public class TestChild extends HadoopTestCase {
                 numMaps, numReds);
     job.setMapperClass(MyMapper.class);
     job.setReducerClass(MyReducer.class);
-    assertFalse("Job already has a job tracker connection, before it's submitted",
-                job.isConnected());
+    assertFalse(
+               job.isConnected(), "Job already has a job tracker connection, before it's submitted");
     job.submit();
-    assertTrue("Job doesn't have a job tracker connection, even though it's been submitted",
-               job.isConnected());
+    assertTrue(
+              job.isConnected(), "Job doesn't have a job tracker connection, even though it's been submitted");
     job.waitForCompletion(true);
     assertTrue(job.isSuccessful());
 
     // Check output directory
     FileSystem fs = FileSystem.get(conf);
-    assertTrue("Job output directory doesn't exit!", fs.exists(outDir));
+    assertTrue(fs.exists(outDir), "Job output directory doesn't exit!");
     FileStatus[] list = fs.listStatus(outDir, new OutputFilter());
     int numPartFiles = numReds == 0 ? numMaps : numReds;
-    assertTrue("Number of part-files is " + list.length + " and not "
-        + numPartFiles, list.length == numPartFiles);
+    assertTrue(list.length == numPartFiles, "Number of part-files is " + list.length + " and not "
+        + numPartFiles);
     return job;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestClientProtocolProviderImpls.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestClientProtocolProviderImpls.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.mapred.LocalJobRunner;
 import org.apache.hadoop.mapred.YARNRunner;
 import org.apache.hadoop.mapreduce.server.jobtracker.JTConfig;
 import org.apache.hadoop.util.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestClientProtocolProviderImpls {
 
@@ -91,9 +91,9 @@ public class TestClientProtocolProviderImpls {
       fail("Cluster init should fail because of non-existing FileSystem");
     } catch (IOException ioEx) {
       final String stackTrace = StringUtils.stringifyException(ioEx);
-      assertTrue("No root cause detected",
-          stackTrace.contains(UnsupportedFileSystemException.class.getName())
-              && stackTrace.contains("nosuchfs"));
+      assertTrue(
+         stackTrace.contains(UnsupportedFileSystemException.class.getName())
+              && stackTrace.contains("nosuchfs"), "No root cause detected");
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestCounters.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestCounters.java
@@ -23,9 +23,9 @@ import org.apache.hadoop.mapreduce.counters.LimitExceededException;
 import org.apache.hadoop.mapreduce.counters.Limits;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * TestCounters checks the sanity and recoverability of {@code Counters}
  */
@@ -46,19 +46,19 @@ public class TestCounters {
       long expectedValue = initValue;
       Counter counter = new Counters().findCounter("test", "foo");
       counter.setValue(initValue);
-      assertEquals("Counter value is not initialized correctly",
-          expectedValue, counter.getValue());
+      assertEquals(
+         expectedValue, counter.getValue(), "Counter value is not initialized correctly");
       for (int j = 0; j < NUMBER_INC; j++) {
         int incValue = rand.nextInt();
         counter.increment(incValue);
         expectedValue += incValue;
-        assertEquals("Counter value is not incremented correctly",
-            expectedValue, counter.getValue());
+        assertEquals(
+           expectedValue, counter.getValue(), "Counter value is not incremented correctly");
       }
       expectedValue = rand.nextInt();
       counter.setValue(expectedValue);
-      assertEquals("Counter value is not set correctly",
-          expectedValue, counter.getValue());
+      assertEquals(
+         expectedValue, counter.getValue(), "Counter value is not set correctly");
     }
   }
 
@@ -148,6 +148,6 @@ public class TestCounters {
       LOG.info("got expected: "+ e);
       return;
     }
-    assertTrue("Should've thrown "+ ecls.getSimpleName(), false);
+    assertTrue(false, "Should've thrown "+ ecls.getSimpleName());
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestLargeSort.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestLargeSort.java
@@ -23,25 +23,25 @@ import org.apache.hadoop.mapred.MiniMRClientCluster;
 import org.apache.hadoop.mapred.MiniMRClientClusterFactory;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestLargeSort {
   MiniMRClientCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     Configuration conf = new YarnConfiguration();
     cluster = MiniMRClientClusterFactory.create(this.getClass(), 2, conf);
     cluster.start();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     if (cluster != null) {
       cluster.stop();
@@ -59,8 +59,8 @@ public class TestLargeSort {
       conf.setInt(MRJobConfig.IO_SORT_MB, ioSortMb);
       conf.setInt(LargeSorter.NUM_MAP_TASKS, 1);
       conf.setInt(LargeSorter.MBS_PER_MAP, ioSortMb);
-      assertEquals("Large sort failed for " + ioSortMb, 0,
-          ToolRunner.run(conf, new LargeSorter(), args));
+      assertEquals(0
+,           ToolRunner.run(conf, new LargeSorter(), args), "Large sort failed for " + ioSortMb);
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestLocalRunner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestLocalRunner.java
@@ -30,7 +30,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,10 +45,10 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Stress tests for the LocalJobRunner
@@ -235,9 +236,9 @@ public class TestLocalRunner {
 
     // Should get a single line of the form "0\t(count)"
     String line = r.readLine().trim();
-    assertTrue("Line does not have correct key", line.startsWith("0\t"));
+    assertTrue(line.startsWith("0\t"), "Line does not have correct key");
     int count = Integer.valueOf(line.substring(2));
-    assertEquals("Incorrect count generated!", TOTAL_RECORDS, count);
+    assertEquals(TOTAL_RECORDS, count, "Incorrect count generated!");
 
     r.close();
 
@@ -276,7 +277,7 @@ public class TestLocalRunner {
     FileOutputFormat.setOutputPath(job, outputPath);
 
     boolean ret = job.waitForCompletion(true);
-    assertTrue("job failed", ret);
+    assertTrue(ret, "job failed");
 
     // This job should have done *some* gc work.
     // It had to clean up 400,000 objects.
@@ -284,7 +285,7 @@ public class TestLocalRunner {
     Counter gcCounter = job.getCounters().findCounter(
         TaskCounter.GC_TIME_MILLIS);
     assertNotNull(gcCounter);
-    assertTrue("No time spent in gc", gcCounter.getValue() > 0);
+    assertTrue(gcCounter.getValue() > 0, "No time spent in gc");
   }
 
 
@@ -292,7 +293,8 @@ public class TestLocalRunner {
    * Run a test with several mappers in parallel, operating at different
    * speeds. Verify that the correct amount of output is created.
    */
-  @Test(timeout=120*1000)
+  @Test
+  @Timeout(value=120)
   public void testMultiMaps() throws Exception {
     Job job = Job.getInstance();
 
@@ -377,7 +379,7 @@ public class TestLocalRunner {
     FileOutputFormat.setOutputPath(job, outputPath);
 
     boolean success = job.waitForCompletion(true);
-    assertFalse("Job succeeded somehow", success);
+    assertFalse(success, "Job succeeded somehow");
   }
 
   /** An IF that creates no splits */
@@ -434,7 +436,7 @@ public class TestLocalRunner {
     FileOutputFormat.setOutputPath(job, outputPath);
 
     boolean success = job.waitForCompletion(true);
-    assertTrue("Empty job should work", success);
+    assertTrue(success, "Empty job should work");
   }
 
   /** @return the directory where numberfiles are written (mapper inputs)  */
@@ -510,7 +512,7 @@ public class TestLocalRunner {
     int expectedPerMapper = maxVal * (maxVal + 1) / 2;
     int expectedSum = expectedPerMapper * numMaps;
     LOG.info("expected sum: " + expectedSum + ", got " + valueSum);
-    assertEquals("Didn't get all our results back", expectedSum, valueSum);
+    assertEquals(expectedSum, valueSum, "Didn't get all our results back");
   }
 
   /**
@@ -551,7 +553,7 @@ public class TestLocalRunner {
     LocalJobRunner.setLocalMaxRunningReduces(job, parallelReduces);
 
     boolean result = job.waitForCompletion(true);
-    assertTrue("Job failed!!", result);
+    assertTrue(result, "Job failed!!");
 
     verifyNumberJob(numMaps);
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRIntermediateDataEncryption.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRIntermediateDataEncryption.java
@@ -33,11 +33,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
@@ -151,7 +151,7 @@ public class TestMRIntermediateDataEncryption {
     });
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     // setup the test root directory
     testRootDir =
@@ -176,13 +176,13 @@ public class TestMRIntermediateDataEncryption {
     fs.mkdirs(jobsDirPath);
     jobInputDirPath = new Path(jobsDirPath, "in-dir");
     // run the input generator job.
-    Assert.assertEquals("Generating input should succeed", 0,
-        generateInputTextFile());
+    Assertions.assertEquals(0
+,         generateInputTextFile(), "Generating input should succeed");
     // run the reference job
     runReferenceJob();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException {
     // shutdown clusters
     if (mrCluster != null) {
@@ -194,7 +194,7 @@ public class TestMRIntermediateDataEncryption {
     // make sure that generated input file is deleted
     final File textInputFile = new File(testRootDir, "input.txt");
     if (textInputFile.exists()) {
-      Assert.assertTrue(textInputFile.delete());
+      Assertions.assertTrue(textInputFile.delete());
     }
   }
 
@@ -290,19 +290,19 @@ public class TestMRIntermediateDataEncryption {
     if (fs.exists(jobRefDirPath) && !fs.delete(jobRefDirPath, true)) {
       throw new IOException("Could not delete " + jobRefDirPath);
     }
-    Assert.assertTrue(fs.mkdirs(jobRefDirPath));
+    Assertions.assertTrue(fs.mkdirs(jobRefDirPath));
     Path jobRefOutputPath = new Path(jobRefDirPath, "out-dir");
     Configuration referenceConf = new Configuration(commonConfig);
     referenceConf.setBoolean(MRJobConfig.MR_ENCRYPTED_INTERMEDIATE_DATA, false);
     Job jobReference = runWordCountJob(jobRefLabel, jobRefOutputPath,
         referenceConf, 4, 1);
-    Assert.assertTrue(jobReference.isSuccessful());
+    Assertions.assertTrue(jobReference.isSuccessful());
     FileStatus[] fileStatusArr =
         fs.listStatus(jobRefOutputPath,
             new Utils.OutputFileUtils.OutputFilesFilter());
-    Assert.assertEquals(1, fileStatusArr.length);
+    Assertions.assertEquals(1, fileStatusArr.length);
     checkSumReference = fs.getFileChecksum(fileStatusArr[0].getPath());
-    Assert.assertTrue(fs.delete(jobRefDirPath, true));
+    Assertions.assertTrue(fs.delete(jobRefDirPath, true));
   }
 
   private static Job runWordCountJob(String postfixName, Path jOutputPath,
@@ -346,8 +346,8 @@ public class TestMRIntermediateDataEncryption {
    * @throws Exception if the output is missing or the combiner job fails.
    */
   private boolean validateJobOutput() throws Exception {
-    Assert.assertTrue("Job Output path [" + jobOutputPath + "] should exist",
-        fs.exists(jobOutputPath));
+    Assertions.assertTrue(
+       fs.exists(jobOutputPath), "Job Output path [" + jobOutputPath + "] should exist");
     Path outputPath = jobOutputPath;
     if (numReducers != 1) {
       // combine the result into one file by running a combiner job
@@ -391,7 +391,7 @@ public class TestMRIntermediateDataEncryption {
     return checkSumReference.equals(jobFileChecksum);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     LOG.info("Starting TestMRIntermediateDataEncryption#{}.......",
         testTitleName);
@@ -435,7 +435,7 @@ public class TestMRIntermediateDataEncryption {
           testTitleName, Time.formatTime(System.currentTimeMillis())));
       Job job = runWordCountJob(testTitleName, jobOutputPath, config,
           numMappers, numReducers);
-      Assert.assertTrue(job.isSuccessful());
+      Assertions.assertTrue(job.isSuccessful());
       long endTime = Time.monotonicNow();
       testSummary.append(String.format("%nJob %s ended at %s",
               job.getJobName(), Time.formatTime(System.currentTimeMillis())));
@@ -451,16 +451,16 @@ public class TestMRIntermediateDataEncryption {
                 fStatus.getPath(), fileSize));
       }
       // Validate the checksum of the output.
-      Assert.assertTrue(validateJobOutput());
+      Assertions.assertTrue(validateJobOutput());
       // Check intermediate files and spilling.
       long spilledRecords =
           job.getCounters().findCounter(TaskCounter.SPILLED_RECORDS).getValue();
-      Assert.assertTrue("Spill records must be greater than 0",
-          spilledRecords > 0);
-      Assert.assertFalse("The encrypted spilled files should not be empty.",
-          spillInjector.getEncryptedSpilledFiles().isEmpty());
-      Assert.assertTrue("Invalid access to spill file positions",
-          spillInjector.getInvalidSpillEntries().isEmpty());
+      Assertions.assertTrue(
+         spilledRecords > 0, "Spill records must be greater than 0");
+      Assertions.assertFalse(
+         spillInjector.getEncryptedSpilledFiles().isEmpty(), "The encrypted spilled files should not be empty.");
+      Assertions.assertTrue(
+         spillInjector.getInvalidSpillEntries().isEmpty(), "Invalid access to spill file positions");
     } finally {
       testSummary.append(spillInjector.getSpilledFileReport());
       LOG.info(testSummary.toString());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMRJobClient.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +50,11 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  test CLI class. CLI class implemented  the Tool interface. 
@@ -65,7 +65,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestMRJobClient.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     setupClassBase(TestMRJobClient.class);
   }
@@ -133,8 +133,8 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
         job.getConfiguration());
     Path submitJobDir = new Path(jobStagingArea, "JobId");
     Path submitJobFile = JobSubmissionFiles.getJobConfPath(submitJobDir);
-    assertFalse("Shouldn't have created a job file if job specs failed.",
-        FileSystem.get(conf).exists(submitJobFile));
+    assertFalse(
+       FileSystem.get(conf).exists(submitJobFile), "Shouldn't have created a job file if job specs failed.");
   }
 
   /**
@@ -191,7 +191,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // TaskAttemptId is not set
     int exitCode = runTool(conf, jc, new String[] { "-fail-task" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
 
     runTool(conf, jc, new String[] { "-fail-task", taid.toString() }, out);
     String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -209,7 +209,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // bad parameters
     int exitCode = runTool(conf, jc, new String[] { "-kill-task" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
 
     runTool(conf, jc, new String[] { "-kill-task", taid.toString() }, out);
     String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -227,10 +227,10 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // without jobId
     int exitCode = runTool(conf, jc, new String[] { "-kill" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     // good parameters
     exitCode = runTool(conf, jc, new String[] { "-kill", jobId }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     
     String answer = new String(out.toByteArray(), StandardCharsets.UTF_8);
     assertTrue(answer.contains("Killed job " + jobId));
@@ -257,12 +257,12 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // bad parameters
     int exitCode = runTool(conf, jc, new String[] { "-submit" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     
     
     exitCode = runTool(conf, jc,
         new String[] { "-submit", fconUri }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String answer = new String(out.toByteArray());
     // in console was written
     assertTrue(answer.contains("Created job "));
@@ -312,10 +312,10 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     int exitCode = runTool(conf, jc, new String[] {
         "-list-blacklisted-trackers", "second in" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, jc, new String[] { "-list-blacklisted-trackers" },
         out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String line;
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
@@ -334,10 +334,10 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     CLI jc = createJobClient();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     int exitCode = runTool(conf, jc, new String[] { "-list-attempt-ids" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, jc, new String[] { "-list-attempt-ids", jobId,
         "MAP", "completed" }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String line;
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
@@ -356,9 +356,9 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     int exitCode = runTool(conf, jc, new String[] { "-list-active-trackers",
         "second parameter" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, jc, new String[] { "-list-active-trackers" }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String line;
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
@@ -387,7 +387,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
         historyFileUri = file.getPath().toUri().toString();
       }
     }
-    assertNotNull("Could not find jhist file", historyFileUri);
+    assertNotNull(historyFileUri, "Could not find jhist file");
 
     for (String historyFileOrJobId : new String[]{historyFileUri, jobId}) {
       // Try a bunch of different valid combinations of the command
@@ -396,7 +396,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "all",
           historyFileOrJobId,
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryHumanOutput(jobId, out);
       File outFile = File.createTempFile("myout", ".txt");
       exitCode = runTool(conf, jc, new String[]{
@@ -406,7 +406,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-outfile",
           outFile.getAbsolutePath()
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryHumanFileOutput(jobId, out, outFile);
       outFile = File.createTempFile("myout", ".txt");
       exitCode = runTool(conf, jc, new String[]{
@@ -418,7 +418,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-format",
           "human"
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryHumanFileOutput(jobId, out, outFile);
       exitCode = runTool(conf, jc, new String[]{
           "-history",
@@ -426,7 +426,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-format",
           "human"
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryHumanOutput(jobId, out);
       exitCode = runTool(conf, jc, new String[]{
           "-history",
@@ -435,7 +435,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-format",
           "json"
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryJSONOutput(jobId, out);
       outFile = File.createTempFile("myout", ".txt");
       exitCode = runTool(conf, jc, new String[]{
@@ -447,7 +447,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-format",
           "json"
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryJSONFileOutput(jobId, out, outFile);
       exitCode = runTool(conf, jc, new String[]{
           "-history",
@@ -455,7 +455,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           "-format",
           "json"
       }, out);
-      assertEquals("Exit code", 0, exitCode);
+      assertEquals(0, exitCode, "Exit code");
       checkHistoryJSONOutput(jobId, out);
 
       // Check some bad arguments
@@ -464,19 +464,19 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
           historyFileOrJobId,
           "foo"
       }, out);
-      assertEquals("Exit code", -1, exitCode);
+      assertEquals(-1, exitCode, "Exit code");
       exitCode = runTool(conf, jc, new String[]{
           "-history",
           historyFileOrJobId,
           "-format"
       }, out);
-      assertEquals("Exit code", -1, exitCode);
+      assertEquals(-1, exitCode, "Exit code");
       exitCode = runTool(conf, jc, new String[]{
           "-history",
           historyFileOrJobId,
           "-outfile",
       }, out);
-      assertEquals("Exit code", -1, exitCode);
+      assertEquals(-1, exitCode, "Exit code");
       try {
         runTool(conf, jc, new String[]{
             "-history",
@@ -553,16 +553,16 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
 
     // bad arguments
     int exitCode = runTool(conf, jc, new String[] { "-config" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, jc, new String[] { "-config job_invalid foo.xml" },
         out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
 
     // good arguments
     File outFile = File.createTempFile("config", ".xml");
     exitCode = runTool(conf, jc, new String[] { "-config", jobId,
         outFile.toString()}, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     BufferedReader br = new BufferedReader(new FileReader(outFile));
     String line = br.readLine();
     br.close();
@@ -577,11 +577,11 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     CLI jc = createJobClient();
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     int exitCode = runTool(conf, jc, new String[] { "-events" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
 
     exitCode = runTool(conf, jc, new String[] { "-events", jobId, "0", "100" },
         out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String line;
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
@@ -603,10 +603,10 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     // bad options
     int exitCode = runTool(conf, jc, new String[] { "-status" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
 
     exitCode = runTool(conf, jc, new String[] { "-status", jobId }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     String line;
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
@@ -629,13 +629,13 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     // bad command 
     int exitCode = runTool(conf, createJobClient(),
         new String[] { "-counter", }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     
     exitCode = runTool(conf, createJobClient(),
         new String[] { "-counter", jobId,
             "org.apache.hadoop.mapreduce.TaskCounter", "MAP_INPUT_RECORDS" },
         out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     assertEquals("Counter", "3", out.toString().trim());
   }
   /**
@@ -648,11 +648,11 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
 
     int exitCode = runTool(conf, createJobClient(), new String[] { "-list",
         "alldata" }, out);
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, createJobClient(),
         // all jobs
         new String[] { "-list", "all" }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     BufferedReader br = new BufferedReader(new InputStreamReader(
         new ByteArrayInputStream(out.toByteArray())));
     String line;
@@ -675,7 +675,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     // only submitted
     int exitCode =
         runTool(conf, createJobClient(), new String[] { "-list" }, out);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     BufferedReader br =
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(
           out.toByteArray())));
@@ -695,7 +695,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     PipedInputStream pis = new PipedInputStream();
     PipedOutputStream pos = new PipedOutputStream(pis);
     int exitCode = runTool(conf, jc, new String[] { "-list", "all" }, pos);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     BufferedReader br = new BufferedReader(new InputStreamReader(pis));
     String line;
     while ((line = br.readLine()) != null) {
@@ -713,10 +713,10 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
       throws Exception {
     int exitCode = runTool(conf, createJobClient(),
         new String[] { "-set-priority" }, new ByteArrayOutputStream());
-    assertEquals("Exit code", -1, exitCode);
+    assertEquals(-1, exitCode, "Exit code");
     exitCode = runTool(conf, createJobClient(), new String[] { "-set-priority",
         jobId, "VERY_LOW" }, new ByteArrayOutputStream());
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     // set-priority is fired after job is completed in YARN, hence need not
     // have to update the priority.
     verifyJobPriority(jobId, "DEFAULT", conf, createJobClient());
@@ -752,7 +752,7 @@ public class TestMRJobClient extends ClusterMapReduceTestCase {
     PipedOutputStream pos = new PipedOutputStream(pis);
     int exitCode = runTool(conf, jc,
         new String[] { "-list", "all" }, pos);
-    assertEquals("Exit code", 0, exitCode);
+    assertEquals(0, exitCode, "Exit code");
     BufferedReader br = new BufferedReader(new InputStreamReader(pis));
     String line = null;
     while ((line = br.readLine()) != null) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMROutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMROutputFormat.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMROutputFormat {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapCollection.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapCollection.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestMapCollection {
 
@@ -81,7 +81,7 @@ public class TestMapCollection {
       }
       len = WritableUtils.readVInt(in);
       for (int i = 0; i < len; ++i) {
-        assertEquals("Invalid byte at " + i, fillChar, in.readByte());
+        assertEquals(fillChar, in.readByte(), "Invalid byte at " + i);
       }
     }
     @Override
@@ -162,10 +162,10 @@ public class TestMapCollection {
         n2 = 0;
       }
       for (int i = s1 + n1; i < l1 - n1; ++i) {
-        assertEquals("Invalid key at " + s1, (int)KeyWritable.keyFill, b1[i]);
+        assertEquals((int)KeyWritable.keyFill, b1[i], "Invalid key at " + s1);
       }
       for (int i = s2 + n2; i < l2 - n2; ++i) {
-        assertEquals("Invalid key at " + s2, (int)KeyWritable.keyFill, b2[i]);
+        assertEquals((int)KeyWritable.keyFill, b2[i], "Invalid key at " + s2);
       }
       return l1 - l2;
     }
@@ -193,7 +193,7 @@ public class TestMapCollection {
     @Override
     protected void cleanup(Context context)
         throws IOException, InterruptedException {
-      assertEquals("Unexpected record count", expected, numrecs);
+      assertEquals(expected, numrecs, "Unexpected record count");
     }
   }
 
@@ -281,7 +281,7 @@ public class TestMapCollection {
         public float getProgress() { return (float) current / records; }
         @Override
         public void close() {
-          assertEquals("Unexpected count", records, current - 1);
+          assertEquals(records, current - 1, "Unexpected count");
         }
       };
     }
@@ -318,7 +318,7 @@ public class TestMapCollection {
     job.setSortComparatorClass(VariableComparator.class);
 
     LOG.info("Running " + name);
-    assertTrue("Job failed!", job.waitForCompletion(false));
+    assertTrue(job.waitForCompletion(false), "Job failed!");
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapReduce.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapReduce.java
@@ -41,10 +41,10 @@ import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.MapFileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**********************************************************
  * MapredLoadTest generates a bunch of work that exercises
@@ -221,7 +221,7 @@ public class TestMapReduce {
   private static int counts = 100;
   private static Random r = new Random();
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(TEST_DIR);
   }
@@ -437,7 +437,7 @@ public class TestMapReduce {
     } finally {
       bw.close();
     }
-    assertTrue("testMapRed failed", success);
+    assertTrue(success, "testMapRed failed");
     fs.delete(testdir, true);
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapReduceLazyOutput.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapReduceLazyOutput.java
@@ -39,9 +39,9 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A JUnit test to test the Map-Reduce framework's feature to create part

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapperReducerCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestMapperReducerCleanup.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.hadoop.mapreduce.lib.reduce.IntSumReducer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestMapperReducerCleanup {
 
@@ -258,9 +258,9 @@ public class TestMapperReducerCleanup {
 
     job.waitForCompletion(true);
 
-    Assert.assertTrue(mapCleanup);
-    Assert.assertTrue(recordReaderCleanup);
-    Assert.assertTrue(recordWriterCleanup);
+    Assertions.assertTrue(mapCleanup);
+    Assertions.assertTrue(recordReaderCleanup);
+    Assertions.assertTrue(recordWriterCleanup);
   }
 
   @Test
@@ -291,10 +291,10 @@ public class TestMapperReducerCleanup {
 
     job.waitForCompletion(true);
 
-    Assert.assertTrue(mapCleanup);
-    Assert.assertTrue(reduceCleanup);
-    Assert.assertTrue(recordReaderCleanup);
-    Assert.assertTrue(recordWriterCleanup);
+    Assertions.assertTrue(mapCleanup);
+    Assertions.assertTrue(reduceCleanup);
+    Assertions.assertTrue(recordReaderCleanup);
+    Assertions.assertTrue(recordWriterCleanup);
   }
   
   @Test
@@ -325,14 +325,14 @@ public class TestMapperReducerCleanup {
 
     job.waitForCompletion(true);
 
-    Assert.assertTrue(mapCleanup);
-    Assert.assertTrue(reduceCleanup);
-    Assert.assertTrue(recordReaderCleanup);
-    Assert.assertTrue(recordWriterCleanup);
+    Assertions.assertTrue(mapCleanup);
+    Assertions.assertTrue(reduceCleanup);
+    Assertions.assertTrue(recordReaderCleanup);
+    Assertions.assertTrue(recordWriterCleanup);
 
-    Assert.assertNotNull(job.getCluster());
+    Assertions.assertNotNull(job.getCluster());
     job.close();
-    Assert.assertNull(job.getCluster());
+    Assertions.assertNull(job.getCluster());
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNewCombinerGrouping.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.mapreduce;
 
-import org.junit.After;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
@@ -31,7 +31,7 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -105,7 +105,7 @@ public class TestNewCombinerGrouping {
 
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(testRootDir);
   }
@@ -156,30 +156,30 @@ public class TestNewCombinerGrouping {
       long combinerOutputRecords = counters.findCounter(
           "org.apache.hadoop.mapreduce.TaskCounter",
           "COMBINE_OUTPUT_RECORDS").getValue();
-      Assert.assertTrue(combinerInputRecords > 0);
-      Assert.assertTrue(combinerInputRecords > combinerOutputRecords);
+      Assertions.assertTrue(combinerInputRecords > 0);
+      Assertions.assertTrue(combinerInputRecords > combinerOutputRecords);
 
       BufferedReader br = new BufferedReader(new FileReader(
           new File(out, "part-r-00000")));
       Set<String> output = new HashSet<String>();
       String line = br.readLine();
-      Assert.assertNotNull(line);
+      Assertions.assertNotNull(line);
       output.add(line.substring(0, 1) + line.substring(4, 5));
       line = br.readLine();
-      Assert.assertNotNull(line);
+      Assertions.assertNotNull(line);
       output.add(line.substring(0, 1) + line.substring(4, 5));
       line = br.readLine();
-      Assert.assertNull(line);
+      Assertions.assertNull(line);
       br.close();
 
       Set<String> expected = new HashSet<String>();
       expected.add("A2");
       expected.add("B5");
 
-      Assert.assertEquals(expected, output);
+      Assertions.assertEquals(expected, output);
 
     } else {
-      Assert.fail("Job failed");
+      Assertions.fail("Job failed");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNoJobSetupCleanup.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestNoJobSetupCleanup.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Ignore
 public class TestNoJobSetupCleanup extends HadoopTestCase {
@@ -58,7 +58,7 @@ public class TestNoJobSetupCleanup extends HadoopTestCase {
     assertTrue(job.getTaskReports(TaskType.MAP).length == numMaps);
     assertTrue(job.getTaskReports(TaskType.REDUCE).length == numReds);
     FileSystem fs = FileSystem.get(conf);
-    assertTrue("Job output directory doesn't exit!", fs.exists(outDir));
+    assertTrue(fs.exists(outDir), "Job output directory doesn't exit!");
 
     // job commit done only in cleanup 
     // therefore output should still be in temp location
@@ -67,8 +67,8 @@ public class TestNoJobSetupCleanup extends HadoopTestCase {
     Path tempWorkingPath = new Path(tempWorkingPathStr);
     FileStatus[] list = fs.listStatus(tempWorkingPath, new OutputFilter());
     int numPartFiles = numReds == 0 ? numMaps : numReds;
-    assertTrue("Number of part-files is " + list.length + " and not "
-        + numPartFiles, list.length == numPartFiles);
+    assertTrue(list.length == numPartFiles, "Number of part-files is " + list.length + " and not "
+        + numPartFiles);
     return job;
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestTaskContext.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestTaskContext.java
@@ -29,12 +29,12 @@ import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil.DataCopyMapper;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil.DataCopyReducer;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Ignore;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests context api and {@link StatusReporter#getProgress()} via 
@@ -49,14 +49,14 @@ public class TestTaskContext extends HadoopTestCase {
   
   private static FileSystem fs = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     fs = FileSystem.getLocal(new Configuration());
     fs.delete(testRootTempDir, true);
     fs.mkdirs(testRootTempDir);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     fs.delete(testRootTempDir, true);
   }
@@ -94,7 +94,7 @@ public class TestTaskContext extends HadoopTestCase {
                 new Path(test, "in"), new Path(test, "out"), numMaps, 0);
     job.setMapperClass(MyMapper.class);
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
     TaskReport[] reports = job.getTaskReports(TaskType.MAP);
     assertEquals(numMaps, reports.length);
     assertEquals(myStatus, reports[0].getState());
@@ -117,7 +117,7 @@ public class TestTaskContext extends HadoopTestCase {
     
     // run the job and wait for completion
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
     
     // check map task reports
     // TODO fix testcase 
@@ -147,8 +147,8 @@ public class TestTaskContext extends HadoopTestCase {
     @Override
     protected void setup(Context context) throws IOException {
       // check if the map task attempt progress is 0
-      assertEquals("Invalid progress in map setup", 
-                   0.0f, context.getProgress(), 0f);
+      assertEquals(0.0f, context.getProgress(), 0f,
+          "Invalid progress in map setup");
       
       // define the progress boundaries
       if (context.getNumReduceTasks() == 0) {
@@ -167,8 +167,8 @@ public class TestTaskContext extends HadoopTestCase {
       // get the weighted map phase progress
       float weightedMapProgress = progressRange * mapPhaseProgress;
       // check the map progress
-      assertEquals("Invalid progress in map", 
-                   weightedMapProgress, context.getProgress(), 0f);
+      assertEquals(weightedMapProgress, context.getProgress(), 0f,
+          "Invalid progress in map");
       
       context.write(new Text(value.toString() + recordCount), value);
     };
@@ -176,8 +176,8 @@ public class TestTaskContext extends HadoopTestCase {
     protected void cleanup(Mapper.Context context) 
     throws IOException, InterruptedException {
       // check if the attempt progress is at the progress boundary 
-      assertEquals("Invalid progress in map cleanup", 
-                   progressRange, context.getProgress(), 0f);
+      assertEquals(progressRange, context.getProgress(), 0f,
+          "Invalid progress in map cleanup");
     };
   }
   
@@ -203,7 +203,7 @@ public class TestTaskContext extends HadoopTestCase {
     job.setMaxMapAttempts(1);
     
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
   }
   
   @SuppressWarnings("unchecked")
@@ -220,9 +220,8 @@ public class TestTaskContext extends HadoopTestCase {
       float weightedReducePhaseProgress = 
         REDUCE_PROGRESS_RANGE * reducePhaseProgress;
       // check that the shuffle phase progress is accounted for
-      assertEquals("Invalid progress in reduce setup",
-                   SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress, 
-                   context.getProgress(), 0.01f);
+      assertEquals(SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress,
+          context.getProgress(), 0.01f, "Invalid progress in reduce setup");
     };
     
     public void reduce(Text key, Iterator<Text> values, Context context)
@@ -230,16 +229,15 @@ public class TestTaskContext extends HadoopTestCase {
       float reducePhaseProgress =  ((float)++recordCount)/INPUT_LINES;
       float weightedReducePhaseProgress = 
         REDUCE_PROGRESS_RANGE * reducePhaseProgress;
-      assertEquals("Invalid progress in reduce", 
-                   SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress, 
-                   context.getProgress(), 0.01f);
+      assertEquals(SHUFFLE_PROGRESS_RANGE + weightedReducePhaseProgress,
+          context.getProgress(), 0.01f, "Invalid progress in reduce");
     }
     
     protected void cleanup(Reducer.Context context) 
     throws IOException, InterruptedException {
       // check if the reduce task has progress of 1 in the end
-      assertEquals("Invalid progress in reduce cleanup", 
-                   1.0f, context.getProgress(), 0f);
+      assertEquals(1.0f, context.getProgress(), 0f,
+          "Invalid progress in reduce cleanup");
     };
   }
   
@@ -268,6 +266,6 @@ public class TestTaskContext extends HadoopTestCase {
     job.setMaxReduceAttempts(1);
     
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestValueIterReset.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestValueIterReset.java
@@ -39,11 +39,11 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A JUnit test to test the Map-Reduce framework's support for the

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestYarnClientProtocolProvider.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/TestYarnClientProtocolProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.spy;
@@ -42,7 +42,7 @@ import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestYarnClientProtocolProvider {
   private static final RecordFactory recordFactory = RecordFactoryProvider.
@@ -62,8 +62,8 @@ public class TestYarnClientProtocolProvider {
     }
     
     try {
-      assertTrue("client is not a LocalJobRunner",
-          cluster.getClient() instanceof LocalJobRunner);
+      assertTrue(
+         cluster.getClient() instanceof LocalJobRunner, "client is not a LocalJobRunner");
     } finally {
       if (cluster != null) {
         cluster.close();
@@ -75,7 +75,7 @@ public class TestYarnClientProtocolProvider {
       conf.set(MRConfig.FRAMEWORK_NAME, MRConfig.YARN_FRAMEWORK_NAME);
       cluster = new Cluster(conf);
       ClientProtocol client = cluster.getClient();
-      assertTrue("client is a YARNRunner", client instanceof YARNRunner);
+      assertTrue(client instanceof YARNRunner, "client is a YARNRunner");
     } catch (IOException e) {
 
     } finally {
@@ -121,8 +121,8 @@ public class TestYarnClientProtocolProvider {
       };
       yrunner.setResourceMgrDelegate(rmgrDelegate);
       Token t = cluster.getDelegationToken(new Text(" "));
-      assertTrue("Token kind is instead " + t.getKind().toString(),
-        "Testclusterkind".equals(t.getKind().toString()));
+      assertTrue(
+       "Testclusterkind".equals(t.getKind().toString()), "Token kind is instead " + t.getKind().toString());
     } finally {
       if (cluster != null) {
         cluster.close();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/filecache/TestURIFragments.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/filecache/TestURIFragments.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapreduce.filecache;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class TestURIFragments {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/aggregate/TestMapReduceAggregates.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/aggregate/TestMapReduceAggregates.java
@@ -28,13 +28,13 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMapReduceAggregates {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestChainErrors.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestChainErrors.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests error conditions in ChainMapper/ChainReducer.
@@ -112,7 +112,7 @@ public class TestChainErrors extends HadoopTestCase {
         LongWritable.class, Text.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job Not failed", !job.isSuccessful());
+    assertTrue(!job.isSuccessful(), "Job Not failed");
   }
 
   /**
@@ -138,7 +138,7 @@ public class TestChainErrors extends HadoopTestCase {
         LongWritable.class, Text.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job Not failed", !job.isSuccessful());
+    assertTrue(!job.isSuccessful(), "Job Not failed");
   }
 
   /**
@@ -161,9 +161,9 @@ public class TestChainErrors extends HadoopTestCase {
         LongWritable.class, Text.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
-    assertEquals("Outputs doesn't match", expectedOutput, MapReduceTestUtil
-        .readOutput(outDir, conf));
+    assertTrue(job.isSuccessful(), "Job failed");
+    assertEquals(expectedOutput, MapReduceTestUtil
+        .readOutput(outDir, conf), "Outputs doesn't match");
   }
 
   /**
@@ -189,9 +189,9 @@ public class TestChainErrors extends HadoopTestCase {
         LongWritable.class, Text.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
-    assertEquals("Outputs doesn't match", expectedOutput, MapReduceTestUtil
-        .readOutput(outDir, conf));
+    assertTrue(job.isSuccessful(), "Job failed");
+    assertEquals(expectedOutput, MapReduceTestUtil
+        .readOutput(outDir, conf), "Outputs doesn't match");
   }
 
   // this map consumes all the input and output nothing

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestMapReduceChain.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestMapReduceChain.java
@@ -30,11 +30,11 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMapReduceChain extends HadoopTestCase {
 
@@ -110,31 +110,31 @@ public class TestMapReduceChain extends HadoopTestCase {
         LongWritable.class, Text.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
 
     String str = "flag not set";
-    assertTrue(str, getFlag(conf, "map.setup.A"));
-    assertTrue(str, getFlag(conf, "map.setup.B"));
-    assertTrue(str, getFlag(conf, "map.setup.C"));
-    assertTrue(str, getFlag(conf, "reduce.setup.R"));
-    assertTrue(str, getFlag(conf, "map.setup.D"));
-    assertTrue(str, getFlag(conf, "map.setup.E"));
-    assertTrue(str, getFlag(conf, "map.setup.F"));
+    assertTrue(getFlag(conf, "map.setup.A"), str);
+    assertTrue(getFlag(conf, "map.setup.B"), str);
+    assertTrue(getFlag(conf, "map.setup.C"), str);
+    assertTrue(getFlag(conf, "reduce.setup.R"), str);
+    assertTrue(getFlag(conf, "map.setup.D"), str);
+    assertTrue(getFlag(conf, "map.setup.E"), str);
+    assertTrue(getFlag(conf, "map.setup.F"), str);
 
-    assertTrue(str, getFlag(conf, "map.A.value.1"));
-    assertTrue(str, getFlag(conf, "map.A.value.2"));
-    assertTrue(str, getFlag(conf, "map.B.value.1A"));
-    assertTrue(str, getFlag(conf, "map.B.value.2A"));
-    assertTrue(str, getFlag(conf, "map.C.value.1AB"));
-    assertTrue(str, getFlag(conf, "map.C.value.2AB"));
-    assertTrue(str, getFlag(conf, "reduce.R.value.1ABC"));
-    assertTrue(str, getFlag(conf, "reduce.R.value.2ABC"));
-    assertTrue(str, getFlag(conf, "map.D.value.1ABCR"));
-    assertTrue(str, getFlag(conf, "map.D.value.2ABCR"));
-    assertTrue(str, getFlag(conf, "map.E.value.1ABCRD"));
-    assertTrue(str, getFlag(conf, "map.E.value.2ABCRD"));
-    assertTrue(str, getFlag(conf, "map.F.value.1ABCRDE"));
-    assertTrue(str, getFlag(conf, "map.F.value.2ABCRDE"));
+    assertTrue(getFlag(conf, "map.A.value.1"), str);
+    assertTrue(getFlag(conf, "map.A.value.2"), str);
+    assertTrue(getFlag(conf, "map.B.value.1A"), str);
+    assertTrue(getFlag(conf, "map.B.value.2A"), str);
+    assertTrue(getFlag(conf, "map.C.value.1AB"), str);
+    assertTrue(getFlag(conf, "map.C.value.2AB"), str);
+    assertTrue(getFlag(conf, "reduce.R.value.1ABC"), str);
+    assertTrue(getFlag(conf, "reduce.R.value.2ABC"), str);
+    assertTrue(getFlag(conf, "map.D.value.1ABCR"), str);
+    assertTrue(getFlag(conf, "map.D.value.2ABCR"), str);
+    assertTrue(getFlag(conf, "map.E.value.1ABCRD"), str);
+    assertTrue(getFlag(conf, "map.E.value.2ABCRD"), str);
+    assertTrue(getFlag(conf, "map.F.value.1ABCRDE"), str);
+    assertTrue(getFlag(conf, "map.F.value.2ABCRDE"), str);
 
     assertTrue(getFlag(conf, "map.cleanup.A"));
     assertTrue(getFlag(conf, "map.cleanup.B"));
@@ -144,8 +144,8 @@ public class TestMapReduceChain extends HadoopTestCase {
     assertTrue(getFlag(conf, "map.cleanup.E"));
     assertTrue(getFlag(conf, "map.cleanup.F"));
 
-    assertEquals("Outputs doesn't match", expectedOutput, MapReduceTestUtil
-        .readOutput(outDir, conf));
+    assertEquals(expectedOutput, MapReduceTestUtil
+        .readOutput(outDir, conf), "Outputs doesn't match");
   }
 
   public static class AMap extends IDMap {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestSingleElementChain.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/chain/TestSingleElementChain.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.lib.map.TokenCounterMapper;
 import org.apache.hadoop.mapreduce.lib.reduce.IntSumReducer;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -64,9 +64,9 @@ public class TestSingleElementChain extends HadoopTestCase {
         IntWritable.class, Text.class, IntWritable.class, null);
 
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
-    assertEquals("Outputs doesn't match", expectedOutput, MapReduceTestUtil
-        .readOutput(outDir, conf));
+    assertTrue(job.isSuccessful(), "Job failed");
+    assertEquals(expectedOutput, MapReduceTestUtil
+        .readOutput(outDir, conf), "Outputs doesn't match");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDBOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDBOutputFormat.java
@@ -24,11 +24,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestDBOutputFormat {
   private String[] fieldNames = new String[] { "id", "name", "value" };

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDataDrivenDBInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestDataDrivenDBInputFormat.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.util.StringUtils;
 import org.hsqldb.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +48,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 //import org.apache.hadoop.examples.DBCountPageView;
 
@@ -124,13 +124,13 @@ public class TestDataDrivenDBInputFormat extends HadoopTestCase {
     createConnection(driverClassName, url);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initialize(DRIVER_CLASS, DB_URL);
     super.setUp();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     super.tearDown();
     shutdown();
@@ -230,11 +230,11 @@ public class TestDataDrivenDBInputFormat extends HadoopTestCase {
         COL, COL);
 
     boolean ret = job.waitForCompletion(true);
-    assertTrue("job failed", ret);
+    assertTrue(ret, "job failed");
 
     // Check to see that we imported as much as we thought we did.
-    assertEquals("Did not get all the records", 4,
-        job.getCounters().findCounter(TaskCounter.REDUCE_OUTPUT_RECORDS)
-        .getValue());
+    assertEquals(4
+,         job.getCounters().findCounter(TaskCounter.REDUCE_OUTPUT_RECORDS)
+        .getValue(), "Did not get all the records");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestIntegerSplitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestIntegerSplitter.java
@@ -17,13 +17,13 @@
  */
 package org.apache.hadoop.mapreduce.lib.db;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestIntegerSplitter {
   private long [] toLongArray(List<Long> in) {
@@ -55,9 +55,9 @@ public class TestIntegerSplitter {
   public void assertLongArrayEquals(long [] expected, long [] actual) {
     for (int i = 0; i < expected.length; i++) {
       try {
-        assertEquals("Failure at position " + i + "; got " + actual[i]
-            + " instead of " + expected[i] + "; actual array is " + formatLongArray(actual),
-            expected[i], actual[i]);
+        assertEquals(
+           expected[i], actual[i], "Failure at position " + i + "; got " + actual[i]
+            + " instead of " + expected[i] + "; actual array is " + formatLongArray(actual));
       } catch (ArrayIndexOutOfBoundsException oob) {
         fail("Expected array with " + expected.length + " elements; got " + actual.length
             + ". Actual array is " + formatLongArray(actual));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestTextSplitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/db/TestTextSplitter.java
@@ -17,14 +17,14 @@
  */
 package org.apache.hadoop.mapreduce.lib.db;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestTextSplitter {
 
@@ -48,9 +48,9 @@ public class TestTextSplitter {
   public void assertArrayEquals(Object [] expected, Object [] actual) {
     for (int i = 0; i < expected.length; i++) {
       try {
-        assertEquals("Failure at position " + i + "; got " + actual[i]
-            + " instead of " + expected[i] + "; actual array is " + formatArray(actual),
-            expected[i], actual[i]);
+        assertEquals(
+           expected[i], actual[i], "Failure at position " + i + "; got " + actual[i]
+            + " instead of " + expected[i] + "; actual array is " + formatArray(actual));
       } catch (ArrayIndexOutOfBoundsException oob) {
         fail("Expected array with " + expected.length + " elements; got " + actual.length
             + ". Actual array is " + formatArray(actual));

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/fieldsel/TestMRFieldSelection.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/fieldsel/TestMRFieldSelection.java
@@ -23,12 +23,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.NumberFormat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMRFieldSelection {
 
@@ -70,7 +70,7 @@ private static NumberFormat idFormat = NumberFormat.getInstance();
     job.setNumReduceTasks(1);
 
     job.waitForCompletion(true);
-    assertTrue("Job Failed!", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job Failed!");
 
     //
     // Finally, we compare the reconstructed answer key with the

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineFileInputFormat.java
@@ -55,18 +55,18 @@ import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat.OneBlockInfo
 import org.apache.hadoop.mapreduce.lib.input.CombineFileInputFormat.OneFileInfo;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.HashMultiset;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.reset;
@@ -106,7 +106,7 @@ public class TestCombineFileInputFormat {
   @Mock
   private List<String> mockList;
 
-  @Before
+  @BeforeEach
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
   }
@@ -261,7 +261,7 @@ public class TestCombineFileInputFormat {
     CombineFileSplit split = new CombineFileSplit(files, lengths);
 
     RecordReader rr = inputFormat.createRecordReader(split, context1);
-    assertTrue("Unexpected RR type!", rr instanceof CombineFileRecordReader);
+    assertTrue(rr instanceof CombineFileRecordReader, "Unexpected RR type!");
 
     // Verify that the initial configuration is the one being used.
     // Right after construction the dummy key should have value "STATE1"
@@ -297,7 +297,7 @@ public class TestCombineFileInputFormat {
 
     CombineFileSplit split = new CombineFileSplit(files, lengths);
     RecordReader rr = inputFormat.createRecordReader(split, context);
-    assertTrue("Unexpected RR type!", rr instanceof CombineFileRecordReader);
+    assertTrue(rr instanceof CombineFileRecordReader, "Unexpected RR type!");
 
     // first initialize() call comes from MapTask. We'll do it here.
     rr.initialize(split, context);
@@ -1485,8 +1485,8 @@ public class TestCombineFileInputFormat {
        * {@link CombineFileInputFormat#createSplits},
        * create only one split on rack1. Otherwise create two splits.
        */
-      assertTrue("Split size should be 1 or 2.",
-          splits.size() == 1 || splits.size() == 2);
+      assertTrue(
+         splits.size() == 1 || splits.size() == 2, "Split size should be 1 or 2.");
       actual.clear();
       reset(mockList);
       for (InputSplit split : splits) {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineSequenceFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineSequenceFileInputFormat.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.mapreduce.lib.input;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.BitSet;
@@ -41,7 +41,8 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,8 @@ public class TestCombineSequenceFileInputFormat {
     new Path(new Path(System.getProperty("test.build.data", "."), "data"),
              "TestCombineSequenceFileInputFormat");
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testFormat() throws IOException, InterruptedException {
     Job job = Job.getInstance(conf);
 
@@ -95,10 +97,10 @@ public class TestCombineSequenceFileInputFormat {
 
       // we should have a single split as the length is comfortably smaller than
       // the block size
-      assertEquals("We got more than one splits!", 1, splits.size());
+      assertEquals(1, splits.size(), "We got more than one splits!");
       InputSplit split = splits.get(0);
-      assertEquals("It should be CombineFileSplit",
-        CombineFileSplit.class, split.getClass());
+      assertEquals(
+       CombineFileSplit.class, split.getClass(), "It should be CombineFileSplit");
 
       // check the split
       BitSet bits = new BitSet(length);
@@ -109,23 +111,23 @@ public class TestCombineSequenceFileInputFormat {
         context.getTaskAttemptID(), reader, null, null,
         MapReduceTestUtil.createDummyReporter(), split);
       reader.initialize(split, mcontext);
-      assertEquals("reader class is CombineFileRecordReader.",
-        CombineFileRecordReader.class, reader.getClass());
+      assertEquals(
+       CombineFileRecordReader.class, reader.getClass(), "reader class is CombineFileRecordReader.");
 
       try {
         while (reader.nextKeyValue()) {
           IntWritable key = reader.getCurrentKey();
           BytesWritable value = reader.getCurrentValue();
-          assertNotNull("Value should not be null.", value);
+          assertNotNull(value, "Value should not be null.");
           final int k = key.get();
           LOG.debug("read " + k);
-          assertFalse("Key in multiple partitions.", bits.get(k));
+          assertFalse(bits.get(k), "Key in multiple partitions.");
           bits.set(k);
         }
       } finally {
         reader.close();
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestCombineTextInputFormat.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.mapreduce.lib.input;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -48,7 +48,8 @@ import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,8 @@ public class TestCombineTextInputFormat {
     new Path(new Path(System.getProperty("test.build.data", "."), "data"),
              "TestCombineTextInputFormat");
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testFormat() throws Exception {
     Job job = Job.getInstance(new Configuration(defaultConf));
 
@@ -100,10 +102,10 @@ public class TestCombineTextInputFormat {
 
       // we should have a single split as the length is comfortably smaller than
       // the block size
-      assertEquals("We got more than one splits!", 1, splits.size());
+      assertEquals(1, splits.size(), "We got more than one splits!");
       InputSplit split = splits.get(0);
-      assertEquals("It should be CombineFileSplit",
-        CombineFileSplit.class, split.getClass());
+      assertEquals(
+       CombineFileSplit.class, split.getClass(), "It should be CombineFileSplit");
 
       // check the split
       BitSet bits = new BitSet(length);
@@ -112,8 +114,8 @@ public class TestCombineTextInputFormat {
         createDummyMapTaskAttemptContext(job.getConfiguration());
       RecordReader<LongWritable, Text> reader =
         format.createRecordReader(split, context);
-      assertEquals("reader class is CombineFileRecordReader.",
-        CombineFileRecordReader.class, reader.getClass());
+      assertEquals(
+       CombineFileRecordReader.class, reader.getClass(), "reader class is CombineFileRecordReader.");
       MapContext<LongWritable,Text,LongWritable,Text> mcontext =
         new MapContextImpl<LongWritable,Text,LongWritable,Text>(job.getConfiguration(),
         context.getTaskAttemptID(), reader, null, null,
@@ -124,11 +126,11 @@ public class TestCombineTextInputFormat {
         int count = 0;
         while (reader.nextKeyValue()) {
           LongWritable key = reader.getCurrentKey();
-          assertNotNull("Key should not be null.", key);
+          assertNotNull(key, "Key should not be null.");
           Text value = reader.getCurrentValue();
           final int v = Integer.parseInt(value.toString());
           LOG.debug("read " + v);
-          assertFalse("Key in multiple partitions.", bits.get(v));
+          assertFalse(bits.get(v), "Key in multiple partitions.");
           bits.set(v);
           count++;
         }
@@ -136,7 +138,7 @@ public class TestCombineTextInputFormat {
       } finally {
         reader.close();
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 
@@ -223,7 +225,8 @@ public class TestCombineTextInputFormat {
   /**
    * Test using the gzip codec for reading
    */
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10)
   public void testGzip() throws IOException, InterruptedException {
     Configuration conf = new Configuration(defaultConf);
     CompressionCodec gzip = new GzipCodec();
@@ -237,9 +240,9 @@ public class TestCombineTextInputFormat {
     FileInputFormat.setInputPaths(job, workDir);
     CombineTextInputFormat format = new CombineTextInputFormat();
     List<InputSplit> splits = format.getSplits(job);
-    assertEquals("compressed splits == 1", 1, splits.size());
+    assertEquals(1, splits.size(), "compressed splits == 1");
     List<Text> results = readSplit(format, splits.get(0), job);
-    assertEquals("splits[0] length", 8, results.size());
+    assertEquals(8, results.size(), "splits[0] length");
 
     final String[] firstList =
       {"the quick", "brown", "fox jumped", "over", " the lazy", " dog"};

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestDelegatingInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestDelegatingInputFormat.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.mapreduce.lib.input;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -83,10 +83,10 @@ public class TestDelegatingInputFormat {
        bins[index]++;
       }
 
-      assertEquals("count is not equal to num splits", numSplits, bins[0]);
-      assertEquals("count is not equal to num splits", numSplits, bins[1]);
-      assertEquals("count is not equal to 2 * num splits",
-        numSplits * 2, bins[2]);
+      assertEquals(numSplits, bins[0], "count is not equal to num splits");
+      assertEquals(numSplits, bins[1], "count is not equal to num splits");
+      assertEquals(
+       numSplits * 2, bins[2], "count is not equal to 2 * num splits");
     } finally {
       if (dfs != null) {
        dfs.shutdown();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestLineRecordReaderJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestLineRecordReaderJobs.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.input;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLineRecordReaderJobs {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRCJCFileInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRCJCFileInputFormat.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import static org.mockito.Mockito.*;
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRKeyValueTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRKeyValueTextInputFormat.java
@@ -41,12 +41,12 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
 import org.apache.hadoop.util.LineReader;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestMRKeyValueTextInputFormat {
   private static final Logger LOG =
@@ -115,8 +115,8 @@ public class TestMRKeyValueTextInputFormat {
           RecordReader<Text, Text> reader = format.createRecordReader(
             splits.get(j), context);
           Class<?> clazz = reader.getClass();
-          assertEquals("reader class is KeyValueLineRecordReader.", 
-            KeyValueLineRecordReader.class, clazz);
+          assertEquals(
+            KeyValueLineRecordReader.class, clazz, "reader class is KeyValueLineRecordReader.");
           MapContext<Text, Text, Text, Text> mcontext = 
             new MapContextImpl<Text, Text, Text, Text>(job.getConfiguration(), 
             context.getTaskAttemptID(), reader, null, null, 
@@ -130,16 +130,16 @@ public class TestMRKeyValueTextInputFormat {
             while (reader.nextKeyValue()) {
               key = reader.getCurrentKey();
               clazz = key.getClass();
-              assertEquals("Key class is Text.", Text.class, clazz);
+              assertEquals(Text.class, clazz, "Key class is Text.");
               value = reader.getCurrentValue();
               clazz = value.getClass();
-              assertEquals("Value class is Text.", Text.class, clazz);
+              assertEquals(Text.class, clazz, "Value class is Text.");
               final int k = Integer.parseInt(key.toString());
               final int v = Integer.parseInt(value.toString());
-              assertEquals("Bad key", 0, k % 2);
-              assertEquals("Mismatched key/value", k / 2, v);
+              assertEquals(0, k % 2, "Bad key");
+              assertEquals(k / 2, v, "Mismatched key/value");
               LOG.debug("read " + v);
-              assertFalse("Key in multiple partitions.", bits.get(v));
+              assertFalse(bits.get(v), "Key in multiple partitions.");
               bits.set(v);
               count++;
             }
@@ -148,7 +148,7 @@ public class TestMRKeyValueTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }
@@ -200,7 +200,7 @@ public class TestMRKeyValueTextInputFormat {
 
       // try splitting the file in a variety of sizes
       KeyValueTextInputFormat format = new KeyValueTextInputFormat();
-      assertTrue("KVTIF claims not splittable", format.isSplitable(job, file));
+      assertTrue(format.isSplitable(job, file), "KVTIF claims not splittable");
       for (int i = 0; i < 3; i++) {
         int numSplits = random.nextInt(MAX_LENGTH / 2000) + 1;
         LOG.info("splitting: requesting = " + numSplits);
@@ -231,10 +231,10 @@ public class TestMRKeyValueTextInputFormat {
               value = reader.getCurrentValue();
               final int k = Integer.parseInt(key.toString());
               final int v = Integer.parseInt(value.toString());
-              assertEquals("Bad key", 0, k % 2);
-              assertEquals("Mismatched key/value", k / 2, v);
+              assertEquals(0, k % 2, "Bad key");
+              assertEquals(k / 2, v, "Mismatched key/value");
               LOG.debug("read " + k + "," + v);
-              assertFalse(k + "," + v + " in multiple partitions.",bits.get(v));
+              assertFalse(bits.get(v), k + "," + v + " in multiple partitions.");
               bits.set(v);
               count++;
             }
@@ -247,7 +247,7 @@ public class TestMRKeyValueTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }
@@ -274,18 +274,18 @@ public class TestMRKeyValueTextInputFormat {
     LineReader in = makeStream("a\nbb\n\nccc\rdddd\r\neeeee");
     Text out = new Text();
     in.readLine(out);
-    assertEquals("line1 length", 1, out.getLength());
+    assertEquals(1, out.getLength(), "line1 length");
     in.readLine(out);
-    assertEquals("line2 length", 2, out.getLength());
+    assertEquals(2, out.getLength(), "line2 length");
     in.readLine(out);
-    assertEquals("line3 length", 0, out.getLength());
+    assertEquals(0, out.getLength(), "line3 length");
     in.readLine(out);
-    assertEquals("line4 length", 3, out.getLength());
+    assertEquals(3, out.getLength(), "line4 length");
     in.readLine(out);
-    assertEquals("line5 length", 4, out.getLength());
+    assertEquals(4, out.getLength(), "line5 length");
     in.readLine(out);
-    assertEquals("line5 length", 5, out.getLength());
-    assertEquals("end of file", 0, in.readLine(out));
+    assertEquals(5, out.getLength(), "line5 length");
+    assertEquals(0, in.readLine(out), "end of file");
   }
   
   private static void writeFile(FileSystem fs, Path name, 
@@ -340,14 +340,14 @@ public class TestMRKeyValueTextInputFormat {
     FileInputFormat.setInputPaths(job, workDir);
     KeyValueTextInputFormat format = new KeyValueTextInputFormat();
     List<InputSplit> splits = format.getSplits(job);
-    assertEquals("compressed splits == 2", 2, splits.size());
+    assertEquals(2, splits.size(), "compressed splits == 2");
     FileSplit tmp = (FileSplit) splits.get(0);
     if (tmp.getPath().getName().equals("part2.txt.gz")) {
       splits.set(0, splits.get(1));
       splits.set(1, tmp);
     }
     List<Text> results = readSplit(format, splits.get(0), job);
-    assertEquals("splits[0] length", 6, results.size());
+    assertEquals(6, results.size(), "splits[0] length");
     assertEquals("splits[0][0]", "the quick", results.get(0).toString());
     assertEquals("splits[0][1]", "brown", results.get(1).toString());
     assertEquals("splits[0][2]", "fox jumped", results.get(2).toString());
@@ -355,7 +355,7 @@ public class TestMRKeyValueTextInputFormat {
     assertEquals("splits[0][4]", " the lazy", results.get(4).toString());
     assertEquals("splits[0][5]", " dog", results.get(5).toString());
     results = readSplit(format, splits.get(1), job);
-    assertEquals("splits[1] length", 2, results.size());
+    assertEquals(2, results.size(), "splits[1] length");
     assertEquals("splits[1][0]", "this is a test", 
                  results.get(0).toString());    
     assertEquals("splits[1][1]", "of gzip", 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsBinaryInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsBinaryInputFormat.java
@@ -32,13 +32,13 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMRSequenceFileAsBinaryInputFormat {
   private static final int RECORDS = 10000;
@@ -104,20 +104,20 @@ public class TestMRSequenceFileAsBinaryInputFormat {
           buf.reset(bval.getBytes(), bval.getLength());
           cmpval.readFields(buf);
           assertTrue(
-            "Keys don't match: " + "*" + cmpkey.toString() + ":" +
-            tkey.toString() + "*",
-            cmpkey.toString().equals(tkey.toString()));
+          
+           cmpkey.toString().equals(tkey.toString()), "Keys don't match: " + "*" + cmpkey.toString() + ":" +
+            tkey.toString() + "*");
           assertTrue(
-            "Vals don't match: " + "*" + cmpval.toString() + ":" +
-            tval.toString() + "*",
-            cmpval.toString().equals(tval.toString()));
+          
+           cmpval.toString().equals(tval.toString()), "Vals don't match: " + "*" + cmpval.toString() + ":" +
+            tval.toString() + "*");
           ++count;
         }
       } finally {
         reader.close();
       }
     }
-    assertEquals("Some records not found", RECORDS, count);
+    assertEquals(RECORDS, count, "Some records not found");
   }
 
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsTextInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileAsTextInputFormat.java
@@ -33,13 +33,13 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestMRSequenceFileAsTextInputFormat {
   private static int MAX_LENGTH = 10000;
@@ -100,15 +100,15 @@ public class TestMRSequenceFileAsTextInputFormat {
             split);
           reader.initialize(split, mcontext);
           Class<?> readerClass = reader.getClass();
-          assertEquals("reader class is SequenceFileAsTextRecordReader.",
-            SequenceFileAsTextRecordReader.class, readerClass);        
+          assertEquals(
+           SequenceFileAsTextRecordReader.class, readerClass, "reader class is SequenceFileAsTextRecordReader.");        
           Text key;
           try {
             int count = 0;
             while (reader.nextKeyValue()) {
               key = reader.getCurrentKey();
               int keyInt = Integer.parseInt(key.toString());
-              assertFalse("Key in multiple partitions.", bits.get(keyInt));
+              assertFalse(bits.get(keyInt), "Key in multiple partitions.");
               bits.set(keyInt);
               count++;
             }
@@ -116,7 +116,7 @@ public class TestMRSequenceFileAsTextInputFormat {
             reader.close();
           }
         }
-        assertEquals("Some keys in no partition.", length, bits.cardinality());
+        assertEquals(length, bits.cardinality(), "Some keys in no partition.");
       }
 
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileInputFilter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMRSequenceFileInputFilter.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestMRSequenceFileInputFilter {
   private static final Logger LOG =

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMultipleInputs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestMultipleInputs.java
@@ -36,9 +36,9 @@ import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @see TestDelegatingInputFormat
@@ -64,7 +64,7 @@ public class TestMultipleInputs extends HadoopTestCase {
     return dir;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     Path rootDir = getDir(ROOT_DIR);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestNLineInputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/input/TestNLineInputFormat.java
@@ -30,14 +30,14 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestNLineInputFormat {
   private static int MAX_LENGTH = 200;
@@ -96,15 +96,15 @@ public class TestNLineInputFormat {
     List<InputSplit> splits = format.getSplits(job);
     int count = 0;
     for (int i = 0; i < splits.size(); i++) {
-      assertEquals("There are no split locations", 0,
-                   splits.get(i).getLocations().length);
+      assertEquals(0
+,                    splits.get(i).getLocations().length, "There are no split locations");
       TaskAttemptContext context = MapReduceTestUtil.
         createDummyMapTaskAttemptContext(job.getConfiguration());
       RecordReader<LongWritable, Text> reader = format.createRecordReader(
         splits.get(i), context);
       Class<?> clazz = reader.getClass();
-      assertEquals("reader class is LineRecordReader.", 
-        LineRecordReader.class, clazz);
+      assertEquals(
+        LineRecordReader.class, clazz, "reader class is LineRecordReader.");
       MapContext<LongWritable, Text, LongWritable, Text> mcontext = 
         new MapContextImpl<LongWritable, Text, LongWritable, Text>(
           job.getConfiguration(), context.getTaskAttemptID(), reader, null,
@@ -120,11 +120,11 @@ public class TestNLineInputFormat {
         reader.close();
       }
       if ( i == splits.size() - 1) {
-        assertEquals("number of lines in split(" + i + ") is wrong" ,
-                     lastN, count);
+        assertEquals( 
+                    lastN, count, "number of lines in split(" + i + ") is wrong");
       } else {
-        assertEquals("number of lines in split(" + i + ") is wrong" ,
-                     expectedN, count);
+        assertEquals( 
+                    expectedN, count, "number of lines in split(" + i + ") is wrong");
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestControlledJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestControlledJob.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.mapreduce.lib.jobcontrol;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestMapReduceJobControl.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestMapReduceJobControl.java
@@ -28,14 +28,15 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.HadoopTestCase;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class performs unit test for Job/JobControl classes.
@@ -202,12 +203,13 @@ public class TestMapReduceJobControl extends HadoopTestCase {
     // wait till all the jobs complete
     waitTillAllFinished(theControl);
     
-    assertEquals("Some jobs failed", 0, theControl.getFailedJobList().size());
+    assertEquals(0, theControl.getFailedJobList().size(), "Some jobs failed");
     
     theControl.stop();
   }
   
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testControlledJob() throws Exception {
     LOG.info("Starting testControlledJob");
 
@@ -222,11 +224,11 @@ public class TestMapReduceJobControl extends HadoopTestCase {
         break;
       }
     }
-    Assert.assertNotNull(cjob1.getMapredJobId());
+    Assertions.assertNotNull(cjob1.getMapredJobId());
 
     // wait till all the jobs complete
     waitTillAllFinished(theControl);
-    assertEquals("Some jobs failed", 0, theControl.getFailedJobList().size());
+    assertEquals(0, theControl.getFailedJobList().size(), "Some jobs failed");
     theControl.stop();
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestMapReduceJobControlWithMocks.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/jobcontrol/TestMapReduceJobControlWithMocks.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.lib.jobcontrol;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +30,7 @@ import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the JobControl API using mock and stub Job instances.
@@ -48,8 +48,8 @@ public class TestMapReduceJobControlWithMocks {
     
     runJobControl(jobControl);
     
-    assertEquals("Success list", 4, jobControl.getSuccessfulJobList().size());
-    assertEquals("Failed list", 0, jobControl.getFailedJobList().size());
+    assertEquals(4, jobControl.getSuccessfulJobList().size(), "Success list");
+    assertEquals(0, jobControl.getFailedJobList().size(), "Failed list");
     
     assertEquals(ControlledJob.State.SUCCESS, job1.getJobState());
     assertEquals(ControlledJob.State.SUCCESS, job2.getJobState());
@@ -70,8 +70,8 @@ public class TestMapReduceJobControlWithMocks {
     
     runJobControl(jobControl);
     
-    assertEquals("Success list", 1, jobControl.getSuccessfulJobList().size());
-    assertEquals("Failed list", 3, jobControl.getFailedJobList().size());
+    assertEquals(1, jobControl.getSuccessfulJobList().size(), "Success list");
+    assertEquals(3, jobControl.getFailedJobList().size(), "Failed list");
 
     assertEquals(ControlledJob.State.FAILED, job1.getJobState());
     assertEquals(ControlledJob.State.SUCCESS, job2.getJobState());
@@ -95,8 +95,8 @@ public class TestMapReduceJobControlWithMocks {
     
     runJobControl(jobControl);
     try {
-      assertEquals("Success list", 0, jobControl.getSuccessfulJobList().size());
-      assertEquals("Failed list", 1, jobControl.getFailedJobList().size());
+      assertEquals(0, jobControl.getSuccessfulJobList().size(), "Success list");
+      assertEquals(1, jobControl.getFailedJobList().size(), "Failed list");
 
       assertEquals(ControlledJob.State.FAILED, job1.getJobState());
     } finally {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinDatamerge.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinDatamerge.java
@@ -33,25 +33,25 @@ import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJoinDatamerge {
 
   private static MiniDFSCluster cluster = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Configuration conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -116,7 +116,7 @@ public class TestJoinDatamerge {
 
     public void setup(Context context) {
       srcs = context.getConfiguration().getInt("testdatamerge.sources", 0);
-      assertTrue("Invalid src count: " + srcs, srcs > 0);
+      assertTrue(srcs > 0, "Invalid src count: " + srcs);
     }
   }
 
@@ -128,7 +128,7 @@ public class TestJoinDatamerge {
 
     public void setup(Context context) {
       srcs = context.getConfiguration().getInt("testdatamerge.sources", 0);
-      assertTrue("Invalid src count: " + srcs, srcs > 0);
+      assertTrue(srcs > 0, "Invalid src count: " + srcs);
     }
 
     public void reduce(IntWritable key, Iterable<IntWritable> values,
@@ -137,7 +137,7 @@ public class TestJoinDatamerge {
       for (IntWritable value : values) {
         seen += value.get();
       }
-      assertTrue("Bad count for " + key.get(), verify(key.get(), seen));
+      assertTrue(verify(key.get(), seen), "Bad count for " + key.get());
       context.write(key, new IntWritable(seen));
     }
     
@@ -150,10 +150,10 @@ public class TestJoinDatamerge {
         throws IOException, InterruptedException {
       int k = key.get();
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
-      assertTrue(kvstr, 0 == k % (srcs * srcs));
+      assertTrue(0 == k % (srcs * srcs), kvstr);
       for (int i = 0; i < val.size(); ++i) {
         final int vali = ((IntWritable)val.get(i)).get();
-        assertTrue(kvstr, (vali - i) * srcs == 10 * k);
+        assertTrue((vali - i) * srcs == 10 * k, kvstr);
       }
       context.write(key, one);
       // If the user modifies the key or any of the values in the tuple, it
@@ -181,18 +181,18 @@ public class TestJoinDatamerge {
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
       if (0 == k % (srcs * srcs)) {
         for (int i = 0; i < val.size(); ++i) {
-          assertTrue(kvstr, val.get(i) instanceof IntWritable);
+          assertTrue(val.get(i) instanceof IntWritable, kvstr);
           final int vali = ((IntWritable)val.get(i)).get();
-          assertTrue(kvstr, (vali - i) * srcs == 10 * k);
+          assertTrue((vali - i) * srcs == 10 * k, kvstr);
         }
       } else {
         for (int i = 0; i < val.size(); ++i) {
           if (i == k % srcs) {
-            assertTrue(kvstr, val.get(i) instanceof IntWritable);
+            assertTrue(val.get(i) instanceof IntWritable, kvstr);
             final int vali = ((IntWritable)val.get(i)).get();
-            assertTrue(kvstr, srcs * (vali - i) == 10 * (k - i));
+            assertTrue(srcs * (vali - i) == 10 * (k - i), kvstr);
           } else {
-            assertTrue(kvstr, !val.has(i));
+            assertTrue(!val.has(i), kvstr);
           }
         }
       }
@@ -224,10 +224,10 @@ public class TestJoinDatamerge {
       final int vali = val.get();
       final String kvstr = "Unexpected tuple: " + stringify(key, val);
       if (0 == k % (srcs * srcs)) {
-        assertTrue(kvstr, vali == k * 10 / srcs + srcs - 1);
+        assertTrue(vali == k * 10 / srcs + srcs - 1, kvstr);
       } else {
         final int i = k % srcs;
-        assertTrue(kvstr, srcs * (vali - i) == 10 * (k - i));
+        assertTrue(srcs * (vali - i) == 10 * (k - i), kvstr);
       }
       context.write(key, one);
       //If the user modifies the key or any of the values in the tuple, it
@@ -267,7 +267,7 @@ public class TestJoinDatamerge {
     job.setOutputKeyClass(IntWritable.class);
     job.setOutputValueClass(IntWritable.class);
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
     if ("outer".equals(jointype)) {
       checkOuterConsistency(job, src);
     }
@@ -289,18 +289,18 @@ public class TestJoinDatamerge {
     Path outf = FileOutputFormat.getOutputPath(job);
     FileStatus[] outlist = cluster.getFileSystem().listStatus(outf, new 
                              Utils.OutputFileUtils.OutputFilesFilter());
-    assertEquals("number of part files is more than 1. It is" + outlist.length,
-      1, outlist.length);
-    assertTrue("output file with zero length" + outlist[0].getLen(),
-      0 < outlist[0].getLen());
+    assertEquals(1, outlist.length,
+        "number of part files is more than 1. It is" + outlist.length);
+    assertTrue(0 < outlist[0].getLen(),
+        "output file with zero length" + outlist[0].getLen());
     SequenceFile.Reader r =
       new SequenceFile.Reader(cluster.getFileSystem(),
           outlist[0].getPath(), job.getConfiguration());
     IntWritable k = new IntWritable();
     IntWritable v = new IntWritable();
     while (r.next(k, v)) {
-      assertEquals("counts does not match", v.get(),
-        countProduct(k, src, job.getConfiguration()));
+      assertEquals(v.get(), countProduct(k, src, job.getConfiguration()),
+          "counts does not match");
     }
     r.close();
   }
@@ -394,7 +394,7 @@ public class TestJoinDatamerge {
     job.setOutputValueClass(TupleWritable.class);
     job.setOutputFormatClass(SequenceFileOutputFormat.class);
     job.waitForCompletion(true);
-    assertTrue("Job failed", job.isSuccessful());
+    assertTrue(job.isSuccessful(), "Job failed");
 
     FileStatus[] outlist = cluster.getFileSystem().listStatus(outf, 
                              new Utils.OutputFileUtils.OutputFilesFilter());

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinProperties.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinProperties.java
@@ -31,12 +31,12 @@ import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.*;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJoinProperties {
 
@@ -47,7 +47,7 @@ public class TestJoinProperties {
   static Path[] src;
   static Path base;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     Configuration conf = new Configuration();
     cluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).build();
@@ -55,7 +55,7 @@ public class TestJoinProperties {
     src = generateSources(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -205,7 +205,7 @@ public class TestJoinProperties {
     String joinExpr = constructExpr1(op);
     conf.set(CompositeInputFormat.JOIN_EXPR, joinExpr);
     int count = testFormat(conf, 2, true, false, ttype);
-    assertTrue("not all keys present", count == expectedCount);
+    assertTrue(count == expectedCount, "not all keys present");
   }
 
   private void testExpr2(Configuration conf, String op, TestType ttype,
@@ -213,7 +213,7 @@ public class TestJoinProperties {
     String joinExpr = constructExpr2(op);
     conf.set(CompositeInputFormat.JOIN_EXPR, joinExpr);
     int count = testFormat(conf, 2, false, true, ttype);
-    assertTrue("not all keys present", count == expectedCount);
+    assertTrue(count == expectedCount, "not all keys present");
   }
 
   private void testExpr3(Configuration conf, String op, TestType ttype,
@@ -221,14 +221,14 @@ public class TestJoinProperties {
     String joinExpr = constructExpr3(op);
     conf.set(CompositeInputFormat.JOIN_EXPR, joinExpr);
     int count = testFormat(conf, 3, false, false, ttype);
-    assertTrue("not all keys present", count == expectedCount);
+    assertTrue(count == expectedCount, "not all keys present");
   }
 
   private void testExpr4(Configuration conf) throws Exception {
     String joinExpr = constructExpr4();
     conf.set(CompositeInputFormat.JOIN_EXPR, joinExpr);
     int count = testFormat(conf, 0, false, false, TestType.INNER_IDENTITY);
-    assertTrue("not all keys present", count == ITEMS);
+    assertTrue(count == ITEMS, "not all keys present");
   }
 
   // outer(outer(A, B), C) == outer(A,outer(B, C)) == outer(A, B, C)
@@ -259,7 +259,7 @@ public class TestJoinProperties {
   private void validateOuterKeyValue(IntWritable k, TupleWritable v, 
       int tupleSize, boolean firstTuple, boolean secondTuple) {
 	final String kvstr = "Unexpected tuple: " + stringify(k, v);
-	assertTrue(kvstr, v.size() == tupleSize);
+	assertTrue(v.size() == tupleSize, kvstr);
 	int key = k.get();
 	IntWritable val0 = null;
 	IntWritable val1 = null;
@@ -269,74 +269,74 @@ public class TestJoinProperties {
       if (key % 2 == 0 && key / 2 <= ITEMS) {
         val0 = (IntWritable)v0.get(0);
       } else {
-        assertFalse(kvstr, v0.has(0));
+        assertFalse(v0.has(0), kvstr);
       }
       if (key % 3 == 0 && key / 3 <= ITEMS) {
         val1 = (IntWritable)v0.get(1);
       } else {
-        assertFalse(kvstr, v0.has(1));
+        assertFalse(v0.has(1), kvstr);
       }
       if (key % 4 == 0 && key / 4 <= ITEMS) {
         val2 = (LongWritable)v.get(1);
       } else {
-        assertFalse(kvstr, v.has(2));
+        assertFalse(v.has(2), kvstr);
       }
     } else if (secondTuple) {
       if (key % 2 == 0 && key / 2 <= ITEMS) {
         val0 = (IntWritable)v.get(0);
       } else {
-        assertFalse(kvstr, v.has(0));
+        assertFalse(v.has(0), kvstr);
       }
       TupleWritable v1 = ((TupleWritable)v.get(1));
       if (key % 3 == 0 && key / 3 <= ITEMS) {
         val1 = (IntWritable)v1.get(0);
       } else {
-        assertFalse(kvstr, v1.has(0));
+        assertFalse(v1.has(0), kvstr);
       }
       if (key % 4 == 0 && key / 4 <= ITEMS) {
         val2 = (LongWritable)v1.get(1);
       } else {
-        assertFalse(kvstr, v1.has(1));
+        assertFalse(v1.has(1), kvstr);
       }
     } else {
       if (key % 2 == 0 && key / 2 <= ITEMS) {
         val0 = (IntWritable)v.get(0);
       } else {
-        assertFalse(kvstr, v.has(0));
+        assertFalse(v.has(0), kvstr);
       }
       if (key % 3 == 0 && key / 3 <= ITEMS) {
         val1 = (IntWritable)v.get(1);
       } else {
-        assertFalse(kvstr, v.has(1));
+        assertFalse(v.has(1), kvstr);
       }
       if (key % 4 == 0 && key / 4 <= ITEMS) {
         val2 = (LongWritable)v.get(2);
       } else {
-        assertFalse(kvstr, v.has(2));
+        assertFalse(v.has(2), kvstr);
       }
     }
 	if (val0 != null) {
-      assertTrue(kvstr, val0.get() == 0);
+      assertTrue(val0.get() == 0, kvstr);
     }
 	if (val1 != null) {
-      assertTrue(kvstr, val1.get() == 1);
+      assertTrue(val1.get() == 1, kvstr);
     }
 	if (val2 != null) {
-      assertTrue(kvstr, val2.get() == 2);
+      assertTrue( val2.get() == 2, kvstr);
     }
   }
 
   private void validateInnerKeyValue(IntWritable k, TupleWritable v,
       int tupleSize, boolean firstTuple, boolean secondTuple) {
 	final String kvstr = "Unexpected tuple: " + stringify(k, v);
-	assertTrue(kvstr, v.size() == tupleSize);
+	assertTrue(v.size() == tupleSize, kvstr);
 	int key = k.get();
 	IntWritable val0 = null;
 	IntWritable val1 = null;
 	LongWritable val2 = null;
-	assertTrue(kvstr, key % 2 == 0 && key / 2 <= ITEMS);
-	assertTrue(kvstr, key % 3 == 0 && key / 3 <= ITEMS);
-	assertTrue(kvstr, key % 4 == 0 && key / 4 <= ITEMS);
+	assertTrue(key % 2 == 0 && key / 2 <= ITEMS, kvstr);
+	assertTrue(key % 3 == 0 && key / 3 <= ITEMS, kvstr);
+	assertTrue(key % 4 == 0 && key / 4 <= ITEMS, kvstr);
 	if (firstTuple) {
       TupleWritable v0 = ((TupleWritable)v.get(0));
       val0 = (IntWritable)v0.get(0);
@@ -352,16 +352,16 @@ public class TestJoinProperties {
       val1 = (IntWritable)v.get(1);
       val2 = (LongWritable)v.get(2);
     }
-    assertTrue(kvstr, val0.get() == 0);
-    assertTrue(kvstr, val1.get() == 1);
-    assertTrue(kvstr, val2.get() == 2);
+    assertTrue(val0.get() == 0, kvstr);
+    assertTrue(val1.get() == 1, kvstr);
+    assertTrue(val2.get() == 2, kvstr);
   }
 
   private void validateKeyValue_INNER_IDENTITY(IntWritable k, IntWritable v) {
     final String kvstr = "Unexpected tuple: " + stringify(k, v);
     int key = k.get();
-    assertTrue(kvstr, (key % 2 == 0 && key / 2 <= ITEMS));
-    assertTrue(kvstr, v.get() == 0);
+    assertTrue((key % 2 == 0 && key / 2 <= ITEMS), kvstr);
+    assertTrue(v.get() == 0, kvstr);
   }
   
   @SuppressWarnings("unchecked")

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinTupleWritable.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestJoinTupleWritable.java
@@ -31,12 +31,12 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestJoinTupleWritable {
 
@@ -96,7 +96,7 @@ public class TestJoinTupleWritable {
         i = verifIter(writs, ((TupleWritable)w), i);
         continue;
       }
-      assertTrue("Bad value", w.equals(writs[i++]));
+      assertTrue(w.equals(writs[i++]), "Bad value");
     }
     return i;
   }
@@ -139,7 +139,7 @@ public class TestJoinTupleWritable {
       new IntWritable(r.nextInt())
     };
     TupleWritable sTuple = makeTuple(writs);
-    assertTrue("Bad count", writs.length == verifIter(writs, sTuple, 0));
+    assertTrue(writs.length == verifIter(writs, sTuple, 0), "Bad count");
   }
 
   @Test
@@ -163,7 +163,7 @@ public class TestJoinTupleWritable {
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     TupleWritable dTuple = new TupleWritable();
     dTuple.readFields(new DataInputStream(in));
-    assertTrue("Failed to write/read tuple", sTuple.equals(dTuple));
+    assertTrue(sTuple.equals(dTuple), "Failed to write/read tuple");
   }
 
   @Test
@@ -184,8 +184,8 @@ public class TestJoinTupleWritable {
     dTuple.readFields(new DataInputStream(in));
     assertThat(dTuple).withFailMessage("Failed to write/read tuple")
         .isEqualTo(sTuple);
-    assertEquals("All tuple data has not been read from the stream", 
-      -1, in.read());
+    assertEquals(
+      -1, in.read(), "All tuple data has not been read from the stream");
   }
 
   @Test
@@ -204,8 +204,8 @@ public class TestJoinTupleWritable {
     dTuple.readFields(new DataInputStream(in));
     assertThat(dTuple).withFailMessage("Failed to write/read tuple")
             .isEqualTo(sTuple);
-    assertEquals("All tuple data has not been read from the stream", 
-      -1, in.read());
+    assertEquals(
+      -1, in.read(), "All tuple data has not been read from the stream");
   }
   
   /**
@@ -230,8 +230,8 @@ public class TestJoinTupleWritable {
     dTuple.readFields(new DataInputStream(in));
     assertThat(dTuple).withFailMessage("Failed to write/read tuple")
         .isEqualTo(sTuple);
-    assertEquals("All tuple data has not been read from the stream", 
-      -1, in.read());
+    assertEquals(
+      -1, in.read(), "All tuple data has not been read from the stream");
   }
 
   @Test
@@ -250,8 +250,8 @@ public class TestJoinTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos,
-          has);
+        assertFalse(
+         has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }
@@ -272,8 +272,8 @@ public class TestJoinTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos,
-          has);
+        assertFalse(
+         has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }
@@ -297,8 +297,8 @@ public class TestJoinTupleWritable {
         assertTrue(has);
       }
       else {
-        assertFalse("Tuple position is incorrectly labelled as set: " + pos,
-          has);
+        assertFalse(
+         has, "Tuple position is incorrectly labelled as set: " + pos);
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestWrappedRRClassloader.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/join/TestWrappedRRClassloader.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestWrappedRRClassloader {
   /**
@@ -87,9 +87,9 @@ public class TestWrappedRRClassloader {
 
     @SuppressWarnings("unchecked")
     public RR_ClassLoaderChecker(Configuration conf) {
-      assertTrue("The class loader has not been inherited from "
-          + CompositeRecordReader.class.getSimpleName(),
-          conf.getClassLoader() instanceof Fake_ClassLoader);
+      assertTrue(
+         conf.getClassLoader() instanceof Fake_ClassLoader, "The class loader has not been inherited from "
+          + CompositeRecordReader.class.getSimpleName());
 
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/map/TestMultithreadedMapper.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/map/TestMultithreadedMapper.java
@@ -27,12 +27,12 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMultithreadedMapper extends HadoopTestCase {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestJobOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestJobOutputCommitter.java
@@ -33,11 +33,11 @@ import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A JUnit test to test Map-Reduce job committer.
@@ -59,14 +59,14 @@ public class TestJobOutputCommitter extends HadoopTestCase {
   private FileSystem fs;
   private Configuration conf = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     conf = createJobConf();
     fs = getFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fs.delete(new Path(TEST_ROOT_DIR), true);
     super.tearDown();
@@ -151,16 +151,16 @@ public class TestJobOutputCommitter extends HadoopTestCase {
     Job job = MapReduceTestUtil.createJob(conf, inDir, outDir, 1, 0);
     job.setOutputFormatClass(output);
 
-    assertTrue("Job failed!", job.waitForCompletion(true));
+    assertTrue(job.waitForCompletion(true), "Job failed!");
 
     Path testFile = new Path(outDir, filename);
-    assertTrue("Done file missing for job " + job.getJobID(), fs.exists(testFile));
+    assertTrue(fs.exists(testFile), "Done file missing for job " + job.getJobID());
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for successful job "
-          + job.getJobID(), fs.exists(file));
+      assertFalse(fs.exists(file), "File " + file + " should not be present for successful job "
+          + job.getJobID());
     }
   }
 
@@ -171,19 +171,19 @@ public class TestJobOutputCommitter extends HadoopTestCase {
     Job job = MapReduceTestUtil.createFailJob(conf, outDir, inDir);
     job.setOutputFormatClass(output);
 
-    assertFalse("Job did not fail!", job.waitForCompletion(true));
+    assertFalse(job.waitForCompletion(true), "Job did not fail!");
 
     if (fileName != null) {
       Path testFile = new Path(outDir, fileName);
-      assertTrue("File " + testFile + " missing for failed job " + job.getJobID(),
-          fs.exists(testFile));
+      assertTrue(
+         fs.exists(testFile), "File " + testFile + " missing for failed job " + job.getJobID());
     }
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for failed job "
-          + job.getJobID(), fs.exists(file));
+      assertFalse(fs.exists(file), "File " + file + " should not be present for failed job "
+          + job.getJobID());
     }
   }
 
@@ -203,19 +203,19 @@ public class TestJobOutputCommitter extends HadoopTestCase {
 
     job.killJob(); // kill the job
 
-    assertFalse("Job did not get kill", job.waitForCompletion(true));
+    assertFalse(job.waitForCompletion(true), "Job did not get kill");
 
     if (fileName != null) {
       Path testFile = new Path(outDir, fileName);
-      assertTrue("File " + testFile + " missing for job " + job.getJobID(), fs
-          .exists(testFile));
+      assertTrue(fs
+          .exists(testFile), "File " + testFile + " missing for job " + job.getJobID());
     }
 
     // check if the files from the missing set exists
     for (String ex : exclude) {
       Path file = new Path(outDir, ex);
-      assertFalse("File " + file + " should not be present for killed job "
-          + job.getJobID(), fs.exists(file));
+      assertFalse(fs.exists(file), "File " + file + " should not be present for killed job "
+          + job.getJobID());
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRCJCFileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRCJCFileOutputCommitter.java
@@ -21,14 +21,14 @@ package org.apache.hadoop.mapreduce.lib.output;
 import java.io.*;
 import java.net.URI;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
@@ -83,12 +83,12 @@ public class TestMRCJCFileOutputCommitter {
     fs.delete(outDir, true);
   }
   
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     cleanup();
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     cleanup();
   }
@@ -178,12 +178,12 @@ public class TestMRCJCFileOutputCommitter {
     committer.abortTask(tContext);
     File expectedFile = new File(new Path(committer.getWorkPath(), partFile)
         .toString());
-    assertFalse("task temp dir still exists", expectedFile.exists());
+    assertFalse(expectedFile.exists(), "task temp dir still exists");
 
     committer.abortJob(jContext, JobStatus.State.FAILED);
     expectedFile = new File(new Path(outDir, FileOutputCommitter.PENDING_DIR_NAME)
         .toString());
-    assertFalse("job temp dir still exists", expectedFile.exists());
+    assertFalse(expectedFile.exists(), "job temp dir still exists");
     assertThat(new File(outDir.toString())
         .listFiles()).withFailMessage("Output directory not empty").isEmpty();
     FileUtil.fullyDelete(new File(outDir.toString()));
@@ -241,7 +241,7 @@ public class TestMRCJCFileOutputCommitter {
     File jobTmpDir = new File(committer.getJobAttemptPath(jContext).toUri().getPath());
     File taskTmpDir = new File(committer.getTaskAttemptPath(tContext).toUri().getPath());
     File expectedFile = new File(taskTmpDir, partFile);
-    assertTrue(expectedFile + " does not exists", expectedFile.exists());
+    assertTrue(expectedFile.exists(), expectedFile + " does not exists");
 
     th = null;
     try {
@@ -252,7 +252,7 @@ public class TestMRCJCFileOutputCommitter {
     assertNotNull(th);
     assertTrue(th instanceof IOException);
     assertTrue(th.getMessage().contains("fake delete failed"));
-    assertTrue("job temp dir does not exists", jobTmpDir.exists());
+    assertTrue(jobTmpDir.exists(), "job temp dir does not exists");
     FileUtil.fullyDelete(new File(outDir.toString()));
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRMultipleOutputs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRMultipleOutputs.java
@@ -34,9 +34,9 @@ import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.Reducer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,9 +44,7 @@ import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -70,17 +68,19 @@ public class TestMRMultipleOutputs extends HadoopTestCase {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(expected = IOException.class)
+  @Test
   public void testParallelCloseIOException() throws IOException, InterruptedException {
-    RecordWriter writer = mock(RecordWriter.class);
-    Map recordWriters = mock(Map.class);
-    when(recordWriters.values()).thenReturn(Arrays.asList(writer, writer));
-    Mapper.Context taskInputOutputContext = mock(Mapper.Context.class);
-    when(taskInputOutputContext.getConfiguration()).thenReturn(createJobConf());
-    doThrow(new IOException("test IO exception")).when(writer).close(taskInputOutputContext);
-    MultipleOutputs<Long, String> mos = new MultipleOutputs<Long, String>(taskInputOutputContext);
-    mos.setRecordWriters(recordWriters);
-    mos.close();
+    assertThrows(IOException.class, () -> {
+      RecordWriter writer = mock(RecordWriter.class);
+      Map recordWriters = mock(Map.class);
+      when(recordWriters.values()).thenReturn(Arrays.asList(writer, writer));
+      Mapper.Context taskInputOutputContext = mock(Mapper.Context.class);
+      when(taskInputOutputContext.getConfiguration()).thenReturn(createJobConf());
+      doThrow(new IOException("test IO exception")).when(writer).close(taskInputOutputContext);
+      MultipleOutputs<Long, String> mos = new MultipleOutputs<Long, String>(taskInputOutputContext);
+      mos.setRecordWriters(recordWriters);
+      mos.close();
+    });
   }
 
   private static String localPathRoot = 
@@ -91,7 +91,7 @@ public class TestMRMultipleOutputs extends HadoopTestCase {
   private static String TEXT = "text";
   private static String SEQUENCE = "sequence";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     Configuration conf = createJobConf();
@@ -99,7 +99,7 @@ public class TestMRMultipleOutputs extends HadoopTestCase {
     fs.delete(ROOT_DIR, true);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     Configuration conf = createJobConf();
     FileSystem fs = FileSystem.get(conf);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRSequenceFileAsBinaryOutputFormat.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/output/TestMRSequenceFileAsBinaryOutputFormat.java
@@ -41,7 +41,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat;
 import org.apache.hadoop.mapreduce.task.MapContextImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +49,8 @@ import java.io.IOException;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestMRSequenceFileAsBinaryOutputFormat {
   private static final Logger LOG =
@@ -139,9 +139,9 @@ public class TestMRSequenceFileAsBinaryOutputFormat {
           iwritable = reader.getCurrentKey();
           dwritable = reader.getCurrentValue();
           assertEquals(
-              "Keys don't match: " + "*" + iwritable.get() + ":" + 
-                                           sourceInt + "*",
-              sourceInt, iwritable.get());
+          
+             sourceInt, iwritable.get(), "Keys don't match: " + "*" + iwritable.get() + ":" + 
+                                           sourceInt + "*");
           assertThat(dwritable.get()).withFailMessage(
               "Vals don't match: " + "*" + dwritable.get() + ":" +
                   sourceDouble + "*").isEqualTo(sourceDouble);
@@ -151,7 +151,7 @@ public class TestMRSequenceFileAsBinaryOutputFormat {
         reader.close();
       }
     }
-    assertEquals("Some records not found", RECORDS, count);
+    assertEquals(RECORDS, count, "Some records not found");
   }
 
   @Test
@@ -162,25 +162,25 @@ public class TestMRSequenceFileAsBinaryOutputFormat {
     job.setOutputKeyClass(FloatWritable.class);
     job.setOutputValueClass(BooleanWritable.class);
 
-    assertEquals("SequenceFileOutputKeyClass should default to ouputKeyClass", 
-      FloatWritable.class,
-      SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(job));
-    assertEquals("SequenceFileOutputValueClass should default to " 
-      + "ouputValueClass", 
-      BooleanWritable.class,
-      SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(job));
+    assertEquals(
+      FloatWritable.class
+,       SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(job), "SequenceFileOutputKeyClass should default to ouputKeyClass");
+    assertEquals(
+      BooleanWritable.class
+,       SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(job), "SequenceFileOutputValueClass should default to " 
+      + "ouputValueClass");
 
     SequenceFileAsBinaryOutputFormat.setSequenceFileOutputKeyClass(job, 
       IntWritable.class );
     SequenceFileAsBinaryOutputFormat.setSequenceFileOutputValueClass(job, 
       DoubleWritable.class ); 
 
-    assertEquals("SequenceFileOutputKeyClass not updated", 
-      IntWritable.class,
-      SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(job));
-    assertEquals("SequenceFileOutputValueClass not updated", 
-      DoubleWritable.class,
-      SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(job));
+    assertEquals(
+      IntWritable.class
+,       SequenceFileAsBinaryOutputFormat.getSequenceFileOutputKeyClass(job), "SequenceFileOutputKeyClass not updated");
+    assertEquals(
+      DoubleWritable.class
+,       SequenceFileAsBinaryOutputFormat.getSequenceFileOutputValueClass(job), "SequenceFileOutputValueClass not updated");
   }
 
   @Test

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestBinaryPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestBinaryPartitioner.java
@@ -22,10 +22,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBinaryPartitioner {
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestInputSampler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestInputSampler.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.mapreduce.lib.partition;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -36,7 +36,8 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestInputSampler {
 
@@ -208,7 +209,8 @@ public class TestInputSampler {
    * Verify SplitSampler contract in mapred.lib.InputSampler, which is added
    * back for binary compatibility of M/R 1.x
    */
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   @SuppressWarnings("unchecked") // IntWritable comparator not typesafe
   public void testMapredSplitSampler() throws Exception {
     final int TOT_SPLITS = 15;
@@ -266,7 +268,8 @@ public class TestInputSampler {
    * Verify IntervalSampler in mapred.lib.InputSampler, which is added back
    * for binary compatibility of M/R 1.x
    */
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   @SuppressWarnings("unchecked") // IntWritable comparator not typesafe
   public void testMapredIntervalSampler() throws Exception {
     final int TOT_SPLITS = 16;

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestKeyFieldHelper.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestKeyFieldHelper.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.mapreduce.lib.partition;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestKeyFieldHelper {
   private static final Logger LOG =
@@ -39,7 +39,7 @@ public class TestKeyFieldHelper {
     String eKeySpecs = keySpecs;
     helper.parseOption(keySpecs);
     String actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     // test -k a.b
     keySpecs = "-k 1.2";
@@ -47,28 +47,28 @@ public class TestKeyFieldHelper {
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr -k1.2,3.4";
     eKeySpecs = "-k1.2,3.4nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr -k1.2,3.4n";
     eKeySpecs = "-k1.2,3.4n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr -k1.2,3.4r";
     eKeySpecs = "-k1.2,3.4r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr -k1.2,3.4 -k5.6,7.8n -k9.10,11.12r -k13.14,15.16nr";
     //1st
@@ -76,142 +76,142 @@ public class TestKeyFieldHelper {
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     // 2nd
     eKeySpecs = "-k5.6,7.8n";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     //3rd
     eKeySpecs = "-k9.10,11.12r";
     actKeySpecs = helper.keySpecs().get(2).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     //4th
     eKeySpecs = "-k13.14,15.16nr";
     actKeySpecs = helper.keySpecs().get(3).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2n,3.4";
     eKeySpecs = "-k1.2,3.4n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2r,3.4";
     eKeySpecs = "-k1.2,3.4r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2nr,3.4";
     eKeySpecs = "-k1.2,3.4nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4n";
     eKeySpecs = "-k1.2,3.4n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4r";
     eKeySpecs = "-k1.2,3.4r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4nr";
     eKeySpecs = "-k1.2,3.4nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr -k1.2,3.4 -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8nr";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-n -k1.2,3.4 -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8n";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-r -k1.2,3.4 -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8r";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4n -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4r -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-k1.2,3.4nr -k5.6,7.8";
     eKeySpecs = "-k1.2,3.4nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     eKeySpecs = "-k5.6,7.8";
     actKeySpecs = helper.keySpecs().get(1).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-n";
     eKeySpecs = "-k1.1,0.0n";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-r";
     eKeySpecs = "-k1.1,0.0r";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
     
     keySpecs = "-nr";
     eKeySpecs = "-k1.1,0.0nr";
     helper = new KeyFieldHelper();
     helper.parseOption(keySpecs);
     actKeySpecs = helper.keySpecs().get(0).toString();
-    assertEquals("KeyFieldHelper's parsing is garbled", eKeySpecs, actKeySpecs);
+    assertEquals(eKeySpecs, actKeySpecs, "KeyFieldHelper's parsing is garbled");
   }
   
   /**
@@ -395,7 +395,7 @@ public class TestKeyFieldHelper {
                                       helper.keySpecs().get(0));
     LOG.info("start : " + start);
     if (expectedOutput == null) {
-      assertEquals("Expected -1 when the start index is invalid", -1, start);
+      assertEquals(-1, start, "Expected -1 when the start index is invalid");
       return;
     }
     // get the end index
@@ -411,8 +411,8 @@ public class TestKeyFieldHelper {
     String output = new String(outputBytes);
     LOG.info("output : " + output);
     LOG.info("expected-output : " + expectedOutput);
-    assertEquals(keySpecs + " failed on input '" + input + "'", 
-                 expectedOutput, output);
+    assertEquals(
+                 expectedOutput, output, keySpecs + " failed on input '" + input + "'");
   }
 
   // check for equality of 2 int arrays

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestMRKeyFieldBasedComparator.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestMRKeyFieldBasedComparator.java
@@ -30,15 +30,15 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.MapReduceTestUtil;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.map.InverseMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class TestMRKeyFieldBasedComparator extends HadoopTestCase {

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestMRKeyFieldBasedPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestMRKeyFieldBasedPartitioner.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.mapreduce.lib.partition;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestMRKeyFieldBasedPartitioner {
 
@@ -36,8 +36,8 @@ public class TestMRKeyFieldBasedPartitioner {
     Configuration conf = new Configuration();
     conf.setInt("num.key.fields.for.partition", 10);
     kfbp.setConf(conf);
-    assertEquals("Empty key should map to 0th partition", 
-                 0, kfbp.getPartition(new Text(), new Text(), numReducers));
+    assertEquals(
+                 0, kfbp.getPartition(new Text(), new Text(), numReducers), "Empty key should map to 0th partition");
     
     // check if the hashcode is correct when no keyspec is specified
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -46,8 +46,8 @@ public class TestMRKeyFieldBasedPartitioner {
     String input = "abc\tdef\txyz";
     int hashCode = input.hashCode();
     int expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // check if the hashcode is correct with specified keyspec
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -58,8 +58,8 @@ public class TestMRKeyFieldBasedPartitioner {
     byte[] eBytes = expectedOutput.getBytes();
     hashCode = kfbp.hashCode(eBytes, 0, eBytes.length - 1, 0);
     expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // test with invalid end index in keyspecs
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -70,8 +70,8 @@ public class TestMRKeyFieldBasedPartitioner {
     eBytes = expectedOutput.getBytes();
     hashCode = kfbp.hashCode(eBytes, 0, eBytes.length - 1, 0);
     expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // test with 0 end index in keyspecs
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -82,16 +82,16 @@ public class TestMRKeyFieldBasedPartitioner {
     eBytes = expectedOutput.getBytes();
     hashCode = kfbp.hashCode(eBytes, 0, eBytes.length - 1, 0);
     expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // test with invalid keyspecs
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
     conf = new Configuration();
     conf.set(KeyFieldBasedPartitioner.PARTITIONER_OPTIONS, "-k10");
     kfbp.setConf(conf);
-    assertEquals("Partitioner doesnt work as expected", 0, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(0, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // test with multiple keyspecs
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -106,8 +106,8 @@ public class TestMRKeyFieldBasedPartitioner {
     eBytes = expectedOutput.getBytes();
     hashCode = kfbp.hashCode(eBytes, 0, eBytes.length - 1, hashCode);
     expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
     
     // test with invalid start index in keyspecs
     kfbp = new KeyFieldBasedPartitioner<Text, Text>();
@@ -121,7 +121,7 @@ public class TestMRKeyFieldBasedPartitioner {
     eBytes = expectedOutput.getBytes();
     hashCode = kfbp.hashCode(eBytes, 0, eBytes.length - 1, hashCode);
     expectedPartition = kfbp.getPartition(hashCode, numReducers);
-    assertEquals("Partitioner doesnt work as expected", expectedPartition, 
-                 kfbp.getPartition(new Text(input), new Text(), numReducers));
+    assertEquals(expectedPartition, 
+                 kfbp.getPartition(new Text(input), new Text(), numReducers), "Partitioner doesnt work as expected");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestTotalOrderPartitioner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/lib/partition/TestTotalOrderPartitioner.java
@@ -38,9 +38,9 @@ import org.apache.hadoop.io.serializer.JavaSerialization;
 import org.apache.hadoop.io.serializer.JavaSerializationComparator;
 import org.apache.hadoop.io.serializer.WritableSerialization;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTotalOrderPartitioner {
 
@@ -158,8 +158,8 @@ public class TestTotalOrderPartitioner {
       partitioner.setConf(conf);
       NullWritable nw = NullWritable.get();
       for (Check<String> chk : testJavaStrings) {
-        assertEquals(chk.data.toString(), chk.part,
-            partitioner.getPartition(chk.data, nw, splitJavaStrings.length + 1));
+        assertEquals(chk.part
+,             partitioner.getPartition(chk.data, nw, splitJavaStrings.length + 1), chk.data.toString());
       }
     } finally {
       p.getFileSystem(conf).delete(p, true);
@@ -178,8 +178,8 @@ public class TestTotalOrderPartitioner {
       partitioner.setConf(conf);
       NullWritable nw = NullWritable.get();
       for (Check<Text> chk : testStrings) {
-        assertEquals(chk.data.toString(), chk.part,
-            partitioner.getPartition(chk.data, nw, splitStrings.length + 1));
+        assertEquals(chk.part
+,             partitioner.getPartition(chk.data, nw, splitStrings.length + 1), chk.data.toString());
       }
     } finally {
       p.getFileSystem(conf).delete(p, true);
@@ -199,8 +199,8 @@ public class TestTotalOrderPartitioner {
       partitioner.setConf(conf);
       NullWritable nw = NullWritable.get();
       for (Check<Text> chk : testStrings) {
-        assertEquals(chk.data.toString(), chk.part,
-            partitioner.getPartition(chk.data, nw, splitStrings.length + 1));
+        assertEquals(chk.part
+,             partitioner.getPartition(chk.data, nw, splitStrings.length + 1), chk.data.toString());
       }
     } finally {
       p.getFileSystem(conf).delete(p, true);
@@ -248,8 +248,8 @@ public class TestTotalOrderPartitioner {
       partitioner.setConf(conf);
       NullWritable nw = NullWritable.get();
       for (Check<Text> chk : revCheck) {
-        assertEquals(chk.data.toString(), chk.part,
-            partitioner.getPartition(chk.data, nw, splitStrings.length + 1));
+        assertEquals(chk.part
+,             partitioner.getPartition(chk.data, nw, splitStrings.length + 1), chk.data.toString());
       }
     } finally {
       p.getFileSystem(conf).delete(p, true);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestBinaryTokenFile.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestBinaryTokenFile.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.mapreduce.security;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -47,10 +47,10 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestBinaryTokenFile {
 
@@ -175,7 +175,7 @@ public class TestBinaryTokenFile {
 
   private static Path p1;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     final Configuration conf = new Configuration();
 
@@ -201,7 +201,7 @@ public class TestBinaryTokenFile {
     p1 = fs.makeQualified(p1);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if(mrCluster != null) {
       mrCluster.stop();
@@ -231,7 +231,7 @@ public class TestBinaryTokenFile {
         os.close();
       }
     } catch (IOException e) {
-      Assert.fail("Exception " + e);
+      Assertions.fail("Exception " + e);
     }
   }
 
@@ -259,7 +259,7 @@ public class TestBinaryTokenFile {
       e.printStackTrace(System.out);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 
   /**
@@ -288,6 +288,6 @@ public class TestBinaryTokenFile {
       e.printStackTrace(System.out);
       fail("Job failed");
     }
-    assertEquals("dist job res is not 0:", 0, res);
+    assertEquals(0, res, "dist job res is not 0:");
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestJHSSecurity.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.mapreduce.security;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -27,7 +27,7 @@ import java.security.PrivilegedExceptionAction;
 
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -52,7 +52,7 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +104,7 @@ public class TestJHSSecurity {
       // Fake the authentication-method
       UserGroupInformation loggedInUser = UserGroupInformation
           .createRemoteUser("testrenewer@APACHE.ORG");
-      Assert.assertEquals("testrenewer", loggedInUser.getShortUserName());
+      Assertions.assertEquals("testrenewer", loggedInUser.getShortUserName());
    // Default realm is APACHE.ORG
       loggedInUser.setAuthenticationMethod(AuthenticationMethod.KERBEROS);
 
@@ -124,7 +124,7 @@ public class TestJHSSecurity {
       try {
         clientUsingDT.getJobReport(jobReportRequest);
       } catch (IOException e) {
-        Assert.assertEquals("Unknown job job_123456_0001", e.getMessage());
+        Assertions.assertEquals("Unknown job job_123456_0001", e.getMessage());
       }
       
    // Renew after 50% of token age.
@@ -147,7 +147,7 @@ public class TestJHSSecurity {
       try {
         clientUsingDT.getJobReport(jobReportRequest);
       } catch (IOException e) {
-        Assert.assertEquals("Unknown job job_123456_0001", e.getMessage());
+        Assertions.assertEquals("Unknown job job_123456_0001", e.getMessage());
       }
       
       // Wait for expiry.

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestMRCredentials.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestMRCredentials.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.mapreduce.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -36,9 +36,9 @@ import org.apache.hadoop.mapred.MiniMRClientCluster;
 import org.apache.hadoop.mapred.MiniMRClientClusterFactory;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests whether a protected secret passed from JobClient is
@@ -54,7 +54,7 @@ public class TestMRCredentials {
   private static JobConf jConf;
 
   @SuppressWarnings("deprecation")
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     System.setProperty("hadoop.log.dir", "logs");
     Configuration conf = new Configuration();
@@ -66,7 +66,7 @@ public class TestMRCredentials {
     createKeysAsJson("keys.json");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if(mrCluster != null)
       mrCluster.stop();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestUmbilicalProtocolWithJobToken.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/TestUmbilicalProtocolWithJobToken.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.event.Level;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /** Unit tests for using Job Token over RPC. 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/ssl/TestEncryptedShuffle.java
@@ -34,11 +34,11 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -50,13 +50,13 @@ public class TestEncryptedShuffle {
 
   private static File testRootDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     testRootDir =
         GenericTestUtils.setupTestRootDir(TestEncryptedShuffle.class);
   }
 
-  @Before
+  @BeforeEach
   public void createCustomYarnClasspath() throws Exception {
     classpathDir = KeyStoreTestUtil.getClasspathDir(TestEncryptedShuffle.class);
     new File(classpathDir, "core-site.xml").delete();
@@ -64,7 +64,7 @@ public class TestEncryptedShuffle {
         Time.monotonicNow()));
   }
 
-  @After
+  @AfterEach
   public void cleanUpMiniClusterSpecialConfig() throws Exception {
     new File(classpathDir, "core-site.xml").delete();
     String keystoresDir = testRootDir.getAbsolutePath();
@@ -151,8 +151,8 @@ public class TestEncryptedShuffle {
       JobClient jobClient = new JobClient(jobConf);
       RunningJob runJob = jobClient.submitJob(jobConf);
       runJob.waitForCompletion();
-      Assert.assertTrue(runJob.isComplete());
-      Assert.assertTrue(runJob.isSuccessful());
+      Assertions.assertTrue(runJob.isComplete());
+      Assertions.assertTrue(runJob.isSuccessful());
     } finally {
       stopCluster();
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/token/delegation/TestDelegationToken.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/security/token/delegation/TestDelegationToken.java
@@ -26,19 +26,19 @@ import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.SecretManager.InvalidToken;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 @Ignore
 public class TestDelegationToken {
   private MiniMRCluster cluster;
   private UserGroupInformation user1;
   private UserGroupInformation user2;
   
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     user1 = UserGroupInformation.createUserForTesting("alice", 
                                                       new String[]{"users"});
@@ -83,8 +83,8 @@ public class TestDelegationToken {
     System.out.println("create time: " + createTime);
     System.out.println("current time: " + currentTime);
     System.out.println("max time: " + maxTime);
-    assertTrue("createTime < current", createTime < currentTime);
-    assertTrue("current < maxTime", currentTime < maxTime);
+    assertTrue(createTime < currentTime, "createTime < current");
+    assertTrue(currentTime < maxTime, "current < maxTime");
 
     // renew should work as user alice
     user1.doAs(new PrivilegedExceptionAction<Void>() {
@@ -102,7 +102,7 @@ public class TestDelegationToken {
       public Void run() throws Exception {
         try {
           bobClient.renewDelegationToken(token);
-          Assert.fail("bob renew");
+          Assertions.fail("bob renew");
         } catch (AccessControlException ace) {
           // PASS
         }
@@ -116,7 +116,7 @@ public class TestDelegationToken {
       public Void run() throws Exception {
         try {
           bobClient.cancelDelegationToken(token);
-          Assert.fail("bob cancel");
+          Assertions.fail("bob cancel");
         } catch (AccessControlException ace) {
           // PASS
         }
@@ -131,7 +131,7 @@ public class TestDelegationToken {
         client.cancelDelegationToken(token);
         try {
           client.cancelDelegationToken(token);
-          Assert.fail("second alice cancel");
+          Assertions.fail("second alice cancel");
         } catch (InvalidToken it) {
           // PASS
         }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/util/TestMRAsyncDiskService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/util/TestMRAsyncDiskService.java
@@ -24,17 +24,17 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.FileUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A test for MRAsyncDiskService.
@@ -47,7 +47,7 @@ public class TestMRAsyncDiskService {
   private static String TEST_ROOT_DIR = new Path(System.getProperty(
       "test.build.data", "/tmp")).toString();
   
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtil.fullyDelete(new File(TEST_ROOT_DIR));
   }
@@ -213,8 +213,8 @@ public class TestMRAsyncDiskService {
     } catch (IOException e) {
       ee = e;
     }
-    assertNotNull("asyncDiskService should not be able to delete files "
-        + "outside all volumes", ee);
+    assertNotNull(ee, "asyncDiskService should not be able to delete files "
+        + "outside all volumes");
     // asyncDiskService is able to automatically find the file in one
     // of the volumes.
     assertTrue(service.moveAndDeleteAbsolutePath(vols[1] + Path.SEPARATOR_CHAR + d));
@@ -325,14 +325,14 @@ public class TestMRAsyncDiskService {
     for (int i = 0; i < vols.length; i++) {
       File subDir = new File(vols[0]);
       String[] subDirContent = subDir.list();
-      assertEquals("Volume should contain a single child: "
-          + MRAsyncDiskService.TOBEDELETED, 1, subDirContent.length);
+      assertEquals(1, subDirContent.length, "Volume should contain a single child: "
+          + MRAsyncDiskService.TOBEDELETED);
       
       File toBeDeletedDir = new File(vols[0], MRAsyncDiskService.TOBEDELETED);
       String[] content = toBeDeletedDir.list();
-      assertNotNull("Cannot find " + toBeDeletedDir, content);
+      assertNotNull(content, "Cannot find " + toBeDeletedDir);
       assertThat(content).withFailMessage(
-          toBeDeletedDir.toString() + " should be empty now.").isEmpty();
+          toBeDeletedDir + " should be empty now.").isEmpty();
     }
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRAMWithNonNormalizedCapabilities.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRAMWithNonNormalizedCapabilities.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.mapreduce.v2;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.mapreduce.SleepJob;
 import org.apache.hadoop.conf.Configuration;
@@ -32,9 +32,9 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public class TestMRAMWithNonNormalizedCapabilities {
           .makeQualified(localFs.getUri(), localFs.getWorkingDirectory());
   static Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
       LOG.info("MRAppJar " + MiniMRYarnCluster.APPJAR
@@ -102,12 +102,12 @@ public class TestMRAMWithNonNormalizedCapabilities {
     job.addFileToClassPath(APP_JAR); // The AppMaster jar itself.
     job.submit();
     boolean completed = job.waitForCompletion(true);
-    Assert.assertTrue("Job should be completed", completed);
-    Assert.assertEquals("Job should be finished successfully", 
-                    JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(completed, "Job should be completed");
+    Assertions.assertEquals(
+                    JobStatus.State.SUCCEEDED, job.getJobState(), "Job should be finished successfully");
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
       LOG.info("MRAppJar " + MiniMRYarnCluster.APPJAR

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRAppWithCombiner.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRAppWithCombiner.java
@@ -41,10 +41,10 @@ import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.mapreduce.Job;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public class TestMRAppWithCombiner {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -88,7 +88,7 @@ public class TestMRAppWithCombiner {
     localFs.setPermission(TestMRJobs.APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -153,7 +153,7 @@ public class TestMRAppWithCombiner {
     public void reduce(K key, Iterator<V> values, OutputCollector<K, V> output,
         Reporter reporter) throws IOException {
       if (Reporter.NULL == reporter) {
-        Assert.fail("A valid Reporter should have been used but, Reporter.NULL is used");
+        Assertions.fail("A valid Reporter should have been used but, Reporter.NULL is used");
       }
     }
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobs.java
@@ -100,12 +100,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Workflow
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.WorkflowPriorityMappingsManager.WorkflowPriorityMapping;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler;
 import org.apache.log4j.Level;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public class TestMRJobs {
   private static final Path TEST_RESOURCES_DIR = new Path(TEST_ROOT_DIR,
       "localizedResources");
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2)
@@ -177,7 +178,7 @@ public class TestMRJobs {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -193,7 +194,7 @@ public class TestMRJobs {
     }
   }
 
-  @After
+  @AfterEach
   public void resetInit() {
     numSleepReducers = DEFAULT_REDUCES;
   }
@@ -231,17 +232,20 @@ public class TestMRJobs {
     localFs.createNewFile(new Path(subDir, "file4.txt"));
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJob() throws Exception {
     testSleepJobInternal(false);
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithRemoteJar() throws Exception {
     testSleepJobInternal(true);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalResourceUnderLimit() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     // set limits to well above what is expected
@@ -252,7 +256,8 @@ public class TestMRJobs {
     testSleepJobInternal(sleepConf, false, true, null);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalResourceSizeOverLimit() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     // set limits to well below what is expected
@@ -263,7 +268,8 @@ public class TestMRJobs {
         ResourceViolation.TOTAL_RESOURCE_SIZE);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalResourceNumberOverLimit() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     // set limits to well below what is expected
@@ -274,7 +280,8 @@ public class TestMRJobs {
         ResourceViolation.NUMBER_OF_RESOURCES);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalResourceCheckAndRemoteJar()
       throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
@@ -286,7 +293,8 @@ public class TestMRJobs {
     testSleepJobInternal(sleepConf, true, true, null);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalIndividualResourceOverLimit()
       throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
@@ -298,7 +306,8 @@ public class TestMRJobs {
         ResourceViolation.SINGLE_RESOURCE_SIZE);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testSleepJobWithLocalIndividualResourceUnderLimit()
       throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
@@ -324,7 +333,7 @@ public class TestMRJobs {
     LOG.info("\n\n\nStarting testSleepJob: useRemoteJar=" + useRemoteJar);
 
     if (!jobSubmissionShouldSucceed && violation == null) {
-      Assert.fail("Test is misconfigured. jobSubmissionShouldSucceed is set"
+      Assertions.fail("Test is misconfigured. jobSubmissionShouldSucceed is set"
           + " to false and a ResourceViolation is not specified.");
     }
 
@@ -356,11 +365,11 @@ public class TestMRJobs {
     job.setMaxMapAttempts(1); // speed up failures
     try {
       job.submit();
-      Assert.assertTrue("JobSubmission succeeded when it should have failed.",
-          jobSubmissionShouldSucceed);
+      Assertions.assertTrue(
+         jobSubmissionShouldSucceed, "JobSubmission succeeded when it should have failed.");
     } catch (IOException e) {
       if (jobSubmissionShouldSucceed) {
-        Assert
+        Assertions
             .fail("Job submission failed when it should have succeeded: " + e);
       }
       switch (violation) {
@@ -368,26 +377,26 @@ public class TestMRJobs {
         if (!e.getMessage().contains(
             "This job has exceeded the maximum number of"
                 + " submitted resources")) {
-          Assert.fail("Test failed unexpectedly: " + e);
+          Assertions.fail("Test failed unexpectedly: " + e);
         }
         break;
 
       case TOTAL_RESOURCE_SIZE:
         if (!e.getMessage().contains(
             "This job has exceeded the maximum size of submitted resources")) {
-          Assert.fail("Test failed unexpectedly: " + e);
+          Assertions.fail("Test failed unexpectedly: " + e);
         }
         break;
 
       case SINGLE_RESOURCE_SIZE:
         if (!e.getMessage().contains(
             "This job has exceeded the maximum size of a single submitted")) {
-          Assert.fail("Test failed unexpectedly: " + e);
+          Assertions.fail("Test failed unexpectedly: " + e);
         }
         break;
 
       default:
-        Assert.fail("Test failed unexpectedly: " + e);
+        Assertions.fail("Test failed unexpectedly: " + e);
         break;
       }
       // we are done with the test (job submission failed)
@@ -396,11 +405,11 @@ public class TestMRJobs {
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue( 
+         trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
     verifySleepJobCounters(job);
     verifyTaskProgress(job);
     
@@ -408,7 +417,8 @@ public class TestMRJobs {
     // JobStatus?)--compare against MRJobConfig.JOB_UBERTASK_ENABLE value
   }
 
-  @Test(timeout = 3000000)
+  @Test
+  @Timeout(value = 3000)
   public void testJobWithChangePriority() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     // Assumption can be removed when FS priority support is implemented
@@ -452,11 +462,12 @@ public class TestMRJobs {
     assertThat(job.getPriority()).isEqualTo(JobPriority.UNDEFINED_PRIORITY);
 
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testJobWithWorkflowPriority() throws Exception {
     Configuration sleepConf = new Configuration(mrCluster.getConfig());
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -496,11 +507,11 @@ public class TestMRJobs {
 
     waitForPriorityToUpdate(job, JobPriority.VERY_LOW);
     // Verify the priority from job itself
-    Assert.assertEquals(JobPriority.VERY_LOW, job.getPriority());
+    Assertions.assertEquals(JobPriority.VERY_LOW, job.getPriority());
 
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
   }
 
   private void waitForPriorityToUpdate(Job job, JobPriority expectedStatus)
@@ -518,13 +529,15 @@ public class TestMRJobs {
     }
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testJobClassloader() throws IOException, InterruptedException,
       ClassNotFoundException {
     testJobClassloader(false);
   }
 
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testJobClassloaderWithCustomClasses() throws IOException,
       InterruptedException, ClassNotFoundException {
     testJobClassloader(true);
@@ -579,8 +592,8 @@ public class TestMRJobs {
     }
     job.submit();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue("Job status: " + job.getStatus().getFailureInfo(),
-        succeeded);
+    Assertions.assertTrue(
+       succeeded, "Job status: " + job.getStatus().getFailureInfo());
   }
 
   public static class CustomOutputFormat<K,V> extends NullOutputFormat<K,V> {
@@ -631,27 +644,28 @@ public class TestMRJobs {
   protected void verifySleepJobCounters(Job job) throws InterruptedException,
       IOException {
     Counters counters = job.getCounters();
-    Assert.assertEquals(3, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
         .getValue());
-    Assert.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
         .getValue());
-    Assert.assertEquals(numSleepReducers,
+    Assertions.assertEquals(numSleepReducers,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES).getValue());
   }
   
   protected void verifyTaskProgress(Job job) throws InterruptedException,
       IOException {
     for (TaskReport taskReport : job.getTaskReports(TaskType.MAP)) {
-      Assert.assertTrue(0.9999f < taskReport.getProgress()
+      Assertions.assertTrue(0.9999f < taskReport.getProgress()
           && 1.0001f > taskReport.getProgress());
     }
     for (TaskReport taskReport : job.getTaskReports(TaskType.REDUCE)) {
-      Assert.assertTrue(0.9999f < taskReport.getProgress()
+      Assertions.assertTrue(0.9999f < taskReport.getProgress()
           && 1.0001f > taskReport.getProgress());
     }
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRandomWriter() throws IOException, InterruptedException,
       ClassNotFoundException {
     
@@ -676,11 +690,11 @@ public class TestMRJobs {
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue( 
+         trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
     
     // Make sure there are three files in the output-dir
     
@@ -695,7 +709,7 @@ public class TestMRJobs {
         count++;
       }
     }
-    Assert.assertEquals("Number of part files is wrong!", 3, count);
+    Assertions.assertEquals(3, count, "Number of part files is wrong!");
     verifyRandomWriterCounters(job);
 
     // TODO later:  add explicit "isUber()" checks of some sort
@@ -704,13 +718,14 @@ public class TestMRJobs {
   protected void verifyRandomWriterCounters(Job job)
       throws InterruptedException, IOException {
     Counters counters = job.getCounters();
-    Assert.assertEquals(3, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
         .getValue());
-    Assert.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
         .getValue());
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFailingMapper() throws IOException, InterruptedException,
       ClassNotFoundException {
 
@@ -737,11 +752,11 @@ public class TestMRJobs {
     }
     
     TaskCompletionEvent[] events = job.getTaskCompletionEvents(0, 2);
-    Assert.assertEquals(TaskCompletionEvent.Status.FAILED, 
+    Assertions.assertEquals(TaskCompletionEvent.Status.FAILED, 
         events[0].getStatus());
-    Assert.assertEquals(TaskCompletionEvent.Status.TIPFAILED, 
+    Assertions.assertEquals(TaskCompletionEvent.Status.TIPFAILED, 
         events[1].getStatus());
-    Assert.assertEquals(JobStatus.State.FAILED, job.getJobState());
+    Assertions.assertEquals(JobStatus.State.FAILED, job.getJobState());
     verifyFailingMapperCounters(job);
 
     // TODO later:  add explicit "isUber()" checks of some sort
@@ -750,13 +765,13 @@ public class TestMRJobs {
   protected void verifyFailingMapperCounters(Job job)
       throws InterruptedException, IOException {
     Counters counters = job.getCounters();
-    Assert.assertEquals(2, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.OTHER_LOCAL_MAPS)
         .getValue());
-    Assert.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
         .getValue());
-    Assert.assertEquals(2, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
         .getValue());
-    Assert
+    Assertions
         .assertTrue(counters.findCounter(JobCounter.SLOTS_MILLIS_MAPS) != null
             && counters.findCounter(JobCounter.SLOTS_MILLIS_MAPS).getValue() != 0);
   }
@@ -785,10 +800,10 @@ public class TestMRJobs {
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertFalse(succeeded);
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+    Assertions.assertFalse(succeeded);
+    Assertions.assertTrue( 
+         trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
     return job;
   }
 
@@ -834,10 +849,10 @@ public class TestMRJobs {
         String trackingUrl = job.getTrackingURL();
         String jobId = job.getJobID().toString();
         job.waitForCompletion(true);
-        Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-        Assert.assertTrue("Tracking URL was " + trackingUrl +
-                          " but didn't Match Job ID " + jobId ,
-          trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+        Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+        Assertions.assertTrue( 
+         trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl +
+                          " but didn't Match Job ID " + jobId);
         return null;
       }
     });
@@ -845,7 +860,8 @@ public class TestMRJobs {
     // TODO later:  add explicit "isUber()" checks of some sort
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testContainerRollingLog() throws IOException,
       InterruptedException, ClassNotFoundException {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -886,7 +902,7 @@ public class TestMRJobs {
         break;
       }
     }
-    Assert.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
+    Assertions.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
         .getRMContext().getRMApps().get(appID).getState());
 
     // Job finished, verify logs
@@ -932,28 +948,28 @@ public class TestMRJobs {
           }
 
           if (foundAppMaster) {
-            Assert.assertSame("Unexpected number of AM sylog* files",
-                sleepConf.getInt(MRJobConfig.MR_AM_LOG_BACKUPS, 0) + 1,
-                sysSiblings.length);
-            Assert.assertTrue("AM syslog.1 length kb should be >= " + amLogKb,
-                sysSiblings[1].getLen() >= amLogKb * 1024);
+            Assertions.assertSame(
+               sleepConf.getInt(MRJobConfig.MR_AM_LOG_BACKUPS, 0) + 1
+,                 sysSiblings.length, "Unexpected number of AM sylog* files");
+            Assertions.assertTrue(
+               sysSiblings[1].getLen() >= amLogKb * 1024, "AM syslog.1 length kb should be >= " + amLogKb);
           } else {
-            Assert.assertSame("Unexpected number of MR task sylog* files",
-                sleepConf.getInt(MRJobConfig.TASK_LOG_BACKUPS, 0) + 1,
-                sysSiblings.length);
-            Assert.assertTrue("MR syslog.1 length kb should be >= " + userLogKb,
-                sysSiblings[1].getLen() >= userLogKb * 1024);
+            Assertions.assertSame(
+               sleepConf.getInt(MRJobConfig.TASK_LOG_BACKUPS, 0) + 1
+,                 sysSiblings.length, "Unexpected number of MR task sylog* files");
+            Assertions.assertTrue(
+               sysSiblings[1].getLen() >= userLogKb * 1024, "MR syslog.1 length kb should be >= " + userLogKb);
           }
         }
       }
     }
     // Make sure we checked non-empty set
     //
-    Assert.assertEquals("No AppMaster log found!", 1, numAppMasters);
+    Assertions.assertEquals(1, numAppMasters, "No AppMaster log found!");
     if (sleepConf.getBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false)) {
-      Assert.assertEquals("MapTask log with uber found!", 0, numMapTasks);
+      Assertions.assertEquals(0, numMapTasks, "MapTask log with uber found!");
     } else {
-      Assert.assertEquals("No MapTask log found!", 1, numMapTasks);
+      Assertions.assertEquals(1, numMapTasks, "No MapTask log found!");
     }
   }
 
@@ -970,27 +986,27 @@ public class TestMRJobs {
 
       // Check that 4 (2 + appjar + DistrubutedCacheChecker jar) files 
       // and 2 archives are present
-      Assert.assertEquals(4, localFiles.length);
-      Assert.assertEquals(4, files.length);
-      Assert.assertEquals(2, localArchives.length);
-      Assert.assertEquals(2, archives.length);
+      Assertions.assertEquals(4, localFiles.length);
+      Assertions.assertEquals(4, files.length);
+      Assertions.assertEquals(2, localArchives.length);
+      Assertions.assertEquals(2, archives.length);
 
       // Check lengths of the files
       Map<String, Path> filesMap = pathsToMap(localFiles);
-      Assert.assertTrue(filesMap.containsKey("distributed.first.symlink"));
-      Assert.assertEquals(1, localFs.getFileStatus(
+      Assertions.assertTrue(filesMap.containsKey("distributed.first.symlink"));
+      Assertions.assertEquals(1, localFs.getFileStatus(
         filesMap.get("distributed.first.symlink")).getLen());
-      Assert.assertTrue(filesMap.containsKey("distributed.second.jar"));
-      Assert.assertTrue(localFs.getFileStatus(
+      Assertions.assertTrue(filesMap.containsKey("distributed.second.jar"));
+      Assertions.assertTrue(localFs.getFileStatus(
         filesMap.get("distributed.second.jar")).getLen() > 1);
 
       // Check extraction of the archive
       Map<String, Path> archivesMap = pathsToMap(localArchives);
-      Assert.assertTrue(archivesMap.containsKey("distributed.third.jar"));
-      Assert.assertTrue(localFs.exists(new Path(
+      Assertions.assertTrue(archivesMap.containsKey("distributed.third.jar"));
+      Assertions.assertTrue(localFs.exists(new Path(
         archivesMap.get("distributed.third.jar"), "distributed.jar.inside3")));
-      Assert.assertTrue(archivesMap.containsKey("distributed.fourth.jar"));
-      Assert.assertTrue(localFs.exists(new Path(
+      Assertions.assertTrue(archivesMap.containsKey("distributed.fourth.jar"));
+      Assertions.assertTrue(localFs.exists(new Path(
         archivesMap.get("distributed.fourth.jar"), "distributed.jar.inside4")));
 
       // Check the class loaders
@@ -998,29 +1014,29 @@ public class TestMRJobs {
       ClassLoader cl = Thread.currentThread().getContextClassLoader();
       // Both the file and the archive should have been added to classpath, so
       // both should be reachable via the class loader.
-      Assert.assertNotNull(cl.getResource("distributed.jar.inside2"));
-      Assert.assertNotNull(cl.getResource("distributed.jar.inside3"));
-      Assert.assertNotNull(cl.getResource("distributed.jar.inside4"));
+      Assertions.assertNotNull(cl.getResource("distributed.jar.inside2"));
+      Assertions.assertNotNull(cl.getResource("distributed.jar.inside3"));
+      Assertions.assertNotNull(cl.getResource("distributed.jar.inside4"));
       // The Job Jar should have been extracted to a folder named "job.jar" and
       // added to the classpath; the two jar files in the lib folder in the Job
       // Jar should have also been added to the classpath
-      Assert.assertNotNull(cl.getResource("job.jar/"));
-      Assert.assertNotNull(cl.getResource("job.jar/lib/lib1.jar"));
-      Assert.assertNotNull(cl.getResource("job.jar/lib/lib2.jar"));
+      Assertions.assertNotNull(cl.getResource("job.jar/"));
+      Assertions.assertNotNull(cl.getResource("job.jar/lib/lib1.jar"));
+      Assertions.assertNotNull(cl.getResource("job.jar/lib/lib2.jar"));
 
       // Check that the symlink for the renaming was created in the cwd;
       File symlinkFile = new File("distributed.first.symlink");
-      Assert.assertTrue(symlinkFile.exists());
-      Assert.assertEquals(1, symlinkFile.length());
+      Assertions.assertTrue(symlinkFile.exists());
+      Assertions.assertEquals(1, symlinkFile.length());
       
       // Check that the symlink for the Job Jar was created in the cwd and
       // points to the extracted directory
       File jobJarDir = new File("job.jar");
       if (Shell.WINDOWS) {
-        Assert.assertTrue(isWindowsSymlinkedDirectory(jobJarDir));
+        Assertions.assertTrue(isWindowsSymlinkedDirectory(jobJarDir));
       } else {
-        Assert.assertTrue(FileUtils.isSymlink(jobJarDir));
-        Assert.assertTrue(jobJarDir.isDirectory());
+        Assertions.assertTrue(FileUtils.isSymlink(jobJarDir));
+        Assertions.assertTrue(jobJarDir.isDirectory());
       }
     }
 
@@ -1136,10 +1152,10 @@ public class TestMRJobs {
     job.submit();
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
-    Assert.assertTrue(job.waitForCompletion(false));
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+    Assertions.assertTrue(job.waitForCompletion(false));
+    Assertions.assertTrue( 
+         trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
   }
   
   private void testDistributedCache(boolean withWildcard) throws Exception {
@@ -1158,17 +1174,20 @@ public class TestMRJobs {
     testDistributedCache(remoteJobJarPath.toUri().toString(), withWildcard);
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDistributedCache() throws Exception {
     testDistributedCache(false);
   }
 
-  @Test (timeout = 300000)
+  @Test
+  @Timeout(value = 300)
   public void testDistributedCacheWithWildcards() throws Exception {
     testDistributedCache(true);
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testThreadDumpOnTaskTimeout() throws IOException,
       InterruptedException, ClassNotFoundException {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -1264,13 +1283,13 @@ public class TestMRJobs {
           if (foundAppMaster) {
             numAppMasters++;
             if (this instanceof TestUberAM) {
-              Assert.assertTrue("No thread dump", foundThreadDump);
+              Assertions.assertTrue(foundThreadDump, "No thread dump");
             } else {
-              Assert.assertFalse("Unexpected thread dump", foundThreadDump);
+              Assertions.assertFalse(foundThreadDump, "Unexpected thread dump");
             }
           } else {
             numMapTasks++;
-            Assert.assertTrue("No thread dump", foundThreadDump);
+            Assertions.assertTrue(foundThreadDump, "No thread dump");
           }
         }
       }
@@ -1278,11 +1297,11 @@ public class TestMRJobs {
 
     // Make sure we checked non-empty set
     //
-    Assert.assertEquals("No AppMaster log found!", 1, numAppMasters);
+    Assertions.assertEquals(1, numAppMasters, "No AppMaster log found!");
     if (sleepConf.getBoolean(MRJobConfig.JOB_UBERTASK_ENABLE, false)) {
-      Assert.assertSame("MapTask log with uber found!", 0, numMapTasks);
+      Assertions.assertSame(0, numMapTasks, "MapTask log with uber found!");
     } else {
-      Assert.assertSame("No MapTask log found!", 1, numMapTasks);
+      Assertions.assertSame(1, numMapTasks, "No MapTask log found!");
     }
   }
 
@@ -1394,10 +1413,10 @@ public class TestMRJobs {
     job.submit();
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
-    Assert.assertTrue(job.waitForCompletion(true));
-    Assert.assertTrue("Tracking URL was " + trackingUrl
-        + " but didn't Match Job ID " + jobId,
-        trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
+    Assertions.assertTrue(job.waitForCompletion(true));
+    Assertions.assertTrue(
+       trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"), "Tracking URL was " + trackingUrl
+        + " but didn't Match Job ID " + jobId);
   }
 
   /**

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithHistoryService.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithHistoryService.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.avro.AvroRemoteException;
 import org.apache.hadoop.mapreduce.SleepJob;
@@ -47,9 +47,10 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.ipc.YarnRPC;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,7 @@ public class TestMRJobsWithHistoryService {
       new Path("target", TestMRJobs.class.getName() + "-tmpDir"));
   static Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
 
-  @Before
+  @BeforeEach
   public void setup() throws InterruptedException, IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -98,7 +99,7 @@ public class TestMRJobsWithHistoryService {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
       LOG.info("MRAppJar " + MiniMRYarnCluster.APPJAR
@@ -111,7 +112,8 @@ public class TestMRJobsWithHistoryService {
     }
   }
 
-  @Test (timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testJobHistoryData() throws IOException, InterruptedException,
       AvroRemoteException, ClassNotFoundException {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -148,14 +150,14 @@ public class TestMRJobsWithHistoryService {
         break;
       }
     }
-    Assert.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
+    Assertions.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
       .getRMContext().getRMApps().get(appID).getState());
     Counters counterHS = job.getCounters();
     //TODO the Assert below worked. need to check
     //Should we compare each field or convert to V2 counter and compare
     LOG.info("CounterHS " + counterHS);
     LOG.info("CounterMR " + counterMR);
-    Assert.assertEquals(counterHS, counterMR);
+    Assertions.assertEquals(counterHS, counterMR);
     
     HSClientProtocol historyClient = instantiateHistoryProxy();
     GetJobReportRequest gjReq = Records.newRecord(GetJobReportRequest.class);
@@ -166,16 +168,16 @@ public class TestMRJobsWithHistoryService {
 
   private void verifyJobReport(JobReport jobReport, JobId jobId) {
     List<AMInfo> amInfos = jobReport.getAMInfos();
-    Assert.assertEquals(1, amInfos.size());
+    Assertions.assertEquals(1, amInfos.size());
     AMInfo amInfo = amInfos.get(0);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(jobId.getAppId(), 1);
     ContainerId amContainerId = ContainerId.newContainerId(appAttemptId, 1);
-    Assert.assertEquals(appAttemptId, amInfo.getAppAttemptId());
-    Assert.assertEquals(amContainerId, amInfo.getContainerId());
-    Assert.assertTrue(jobReport.getSubmitTime() > 0);
-    Assert.assertTrue(jobReport.getStartTime() > 0
+    Assertions.assertEquals(appAttemptId, amInfo.getAppAttemptId());
+    Assertions.assertEquals(amContainerId, amInfo.getContainerId());
+    Assertions.assertTrue(jobReport.getSubmitTime() > 0);
+    Assertions.assertTrue(jobReport.getStartTime() > 0
         && jobReport.getStartTime() >= jobReport.getSubmitTime());
-    Assert.assertTrue(jobReport.getFinishTime() > 0
+    Assertions.assertTrue(jobReport.getFinishTime() > 0
         && jobReport.getFinishTime() >= jobReport.getStartTime());
   }
   

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithProfiler.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMRJobsWithProfiler.java
@@ -24,8 +24,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.mapreduce.SleepJob;
 import org.apache.hadoop.conf.Configuration;
@@ -39,8 +39,9 @@ import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ public class TestMRJobsWithProfiler {
 
   private static final Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws InterruptedException, IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -95,7 +96,7 @@ public class TestMRJobsWithProfiler {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
       LOG.info("MRAppJar " + MiniMRYarnCluster.APPJAR
@@ -108,7 +109,8 @@ public class TestMRJobsWithProfiler {
     }
   }
 
-  @Test (timeout = 150000)
+  @Test
+  @Timeout(value = 150)
   public void testDefaultProfiler() throws Exception {
     assumeFalse("The hprof agent has been removed since Java 9. Skipping.",
         Shell.isJavaVersionAtLeast(9));
@@ -116,7 +118,8 @@ public class TestMRJobsWithProfiler {
     testProfilerInternal(true);
   }
 
-  @Test (timeout = 150000)
+  @Test
+  @Timeout(value = 150)
   public void testDifferentProfilers() throws Exception {
     LOG.info("Starting testDefaultProfiler");
     testProfilerInternal(false);
@@ -179,7 +182,7 @@ public class TestMRJobsWithProfiler {
         break;
       }
     }
-    Assert.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
+    Assertions.assertEquals(RMAppState.FINISHED, mrCluster.getResourceManager()
       .getRMContext().getRMApps().get(appID).getState());
 
     // Job finished, verify logs
@@ -222,7 +225,7 @@ public class TestMRJobsWithProfiler {
       }
     }
 
-    Assert.assertEquals(4, taLogDirs.size());  // all 4 attempts found
+    Assertions.assertEquals(4, taLogDirs.size());  // all 4 attempts found
 
     // Skip checking the contents because the JFR dumps binary files
     if (Shell.isJavaVersionAtLeast(9)) {
@@ -241,17 +244,17 @@ public class TestMRJobsWithProfiler {
           final BufferedReader br = new BufferedReader(new InputStreamReader(
             localFs.open(profilePath)));
           final String line = br.readLine();
-          Assert.assertTrue("No hprof content found!",
-            line !=null && line.startsWith("JAVA PROFILE"));
+          Assertions.assertTrue(
+           line !=null && line.startsWith("JAVA PROFILE"), "No hprof content found!");
           br.close();
-          Assert.assertEquals(0L, localFs.getFileStatus(stdoutPath).getLen());
+          Assertions.assertEquals(0L, localFs.getFileStatus(stdoutPath).getLen());
         } else {
-          Assert.assertFalse("hprof file should not exist",
-            localFs.exists(profilePath));
+          Assertions.assertFalse(
+           localFs.exists(profilePath), "hprof file should not exist");
         }
       } else {
-        Assert.assertFalse("hprof file should not exist",
-          localFs.exists(profilePath));
+        Assertions.assertFalse(
+         localFs.exists(profilePath), "hprof file should not exist");
         if (tid.getTaskID().getId() == PROFILED_TASK_ID) {
           // reducer is profiled with Xprof
           final BufferedReader br = new BufferedReader(new InputStreamReader(
@@ -265,9 +268,9 @@ public class TestMRJobsWithProfiler {
             }
           }
           br.close();
-          Assert.assertTrue("Xprof flat profile not found!", flatProfFound);
+          Assertions.assertTrue(flatProfFound, "Xprof flat profile not found!");
         } else {
-          Assert.assertEquals(0L, localFs.getFileStatus(stdoutPath).getLen());
+          Assertions.assertEquals(0L, localFs.getFileStatus(stdoutPath).getLen());
         }
       }
     }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMROldApiJobs.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMROldApiJobs.java
@@ -40,10 +40,10 @@ import org.apache.hadoop.mapred.lib.IdentityMapper;
 import org.apache.hadoop.mapred.lib.IdentityReducer;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +63,7 @@ public class TestMROldApiJobs {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()  throws IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -88,7 +88,7 @@ public class TestMROldApiJobs {
     localFs.setPermission(TestMRJobs.APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -117,12 +117,12 @@ public class TestMROldApiJobs {
     runJobSucceed(conf, in, out);
     
     FileSystem fs = FileSystem.get(conf);
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_SETUP_FILE_NAME)));
-    Assert.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.JOB_ABORT_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_COMMIT_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_SETUP_FILE_NAME)));
-    Assert.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.TASK_ABORT_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_COMMIT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_SETUP_FILE_NAME)));
+    Assertions.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.JOB_ABORT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_COMMIT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_SETUP_FILE_NAME)));
+    Assertions.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.TASK_ABORT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_COMMIT_FILE_NAME)));
   }
 
   @Test
@@ -146,12 +146,12 @@ public class TestMROldApiJobs {
     runJobFail(conf, in, out);
     
     FileSystem fs = FileSystem.get(conf);
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_SETUP_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_ABORT_FILE_NAME)));
-    Assert.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.JOB_COMMIT_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_SETUP_FILE_NAME)));
-    Assert.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_ABORT_FILE_NAME)));
-    Assert.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.TASK_COMMIT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_SETUP_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.JOB_ABORT_FILE_NAME)));
+    Assertions.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.JOB_COMMIT_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_SETUP_FILE_NAME)));
+    Assertions.assertTrue(fs.exists(new Path(out, CustomOutputCommitter.TASK_ABORT_FILE_NAME)));
+    Assertions.assertFalse(fs.exists(new Path(out, CustomOutputCommitter.TASK_COMMIT_FILE_NAME)));
   }
 
   //Run a job that will be failed and wait until it completes
@@ -164,7 +164,7 @@ public class TestMROldApiJobs {
     conf.setMaxMapAttempts(1);
     
     boolean success = runJob(conf, inDir, outDir, 1, 0);
-    Assert.assertFalse("Job expected to fail succeeded", success);
+    Assertions.assertFalse(success, "Job expected to fail succeeded");
   }
 
   //Run a job that will be succeeded and wait until it completes
@@ -176,7 +176,7 @@ public class TestMROldApiJobs {
     conf.setReducerClass(IdentityReducer.class);
     
     boolean success = runJob(conf, inDir, outDir, 1 , 1);
-    Assert.assertTrue("Job expected to succeed failed", success);
+    Assertions.assertTrue(success, "Job expected to succeed failed");
   }
 
   static boolean runJob(JobConf conf, Path inDir, Path outDir, int numMaps, 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMiniMRProxyUser.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestMiniMRProxyUser.java
@@ -28,24 +28,24 @@ import org.apache.hadoop.mapred.MiniMRCluster;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.ProxyUsers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.InetAddress;
 import java.security.PrivilegedExceptionAction;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestMiniMRProxyUser {
 
   private MiniDFSCluster dfsCluster = null;
   private MiniMRCluster mrCluster = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     if (System.getProperty("hadoop.log.dir") == null) {
       System.setProperty("hadoop.log.dir", "/tmp");
@@ -93,7 +93,7 @@ public class TestMiniMRProxyUser {
     return mrCluster.createJobConf();
   }
   
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (mrCluster != null) {
       mrCluster.shutdown();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestNonExistentJob.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestNonExistentJob.java
@@ -27,20 +27,20 @@ import org.apache.hadoop.mapred.JobID;
 import org.apache.hadoop.mapred.MiniMRCluster;
 import org.apache.hadoop.mapred.RunningJob;
 import org.apache.hadoop.security.authorize.ProxyUsers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestNonExistentJob {
 
   private MiniDFSCluster dfsCluster = null;
   private MiniMRCluster mrCluster = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     if (System.getProperty("hadoop.log.dir") == null) {
       System.setProperty("hadoop.log.dir", "/tmp");
@@ -81,7 +81,7 @@ public class TestNonExistentJob {
     return mrCluster.createJobConf();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (mrCluster != null) {
       mrCluster.shutdown();

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestRMNMInfo.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestRMNMInfo.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMContext;
 import org.apache.hadoop.yarn.server.resourcemanager.RMNMInfo;
 import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +64,7 @@ public class TestRMNMInfo {
               .makeQualified(localFs.getUri(), localFs.getWorkingDirectory());
   static Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -86,7 +86,7 @@ public class TestRMNMInfo {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -109,27 +109,27 @@ public class TestRMNMInfo {
     String liveNMs = rmInfo.getLiveNodeManagers();
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jn = mapper.readTree(liveNMs);
-    Assert.assertEquals("Unexpected number of live nodes:",
-                                               NUMNODEMANAGERS, jn.size());
+    Assertions.assertEquals(
+                                              NUMNODEMANAGERS, jn.size(), "Unexpected number of live nodes:");
     Iterator<JsonNode> it = jn.iterator();
     while (it.hasNext()) {
       JsonNode n = it.next();
-      Assert.assertNotNull(n.get("HostName"));
-      Assert.assertNotNull(n.get("Rack"));
-      Assert.assertTrue("Node " + n.get("NodeId") + " should be RUNNING",
-              n.get("State").asText().contains("RUNNING"));
-      Assert.assertNotNull(n.get("NodeHTTPAddress"));
-      Assert.assertNotNull(n.get("LastHealthUpdate"));
-      Assert.assertNotNull(n.get("HealthReport"));
-      Assert.assertNotNull(n.get("NodeManagerVersion"));
-      Assert.assertNotNull(n.get("NumContainers"));
-      Assert.assertEquals(
-              n.get("NodeId") + ": Unexpected number of used containers",
-              0, n.get("NumContainers").asInt());
-      Assert.assertEquals(
-              n.get("NodeId") + ": Unexpected amount of used memory",
-              0, n.get("UsedMemoryMB").asInt());
-      Assert.assertNotNull(n.get("AvailableMemoryMB"));
+      Assertions.assertNotNull(n.get("HostName"));
+      Assertions.assertNotNull(n.get("Rack"));
+      Assertions.assertTrue(
+             n.get("State").asText().contains("RUNNING"), "Node " + n.get("NodeId") + " should be RUNNING");
+      Assertions.assertNotNull(n.get("NodeHTTPAddress"));
+      Assertions.assertNotNull(n.get("LastHealthUpdate"));
+      Assertions.assertNotNull(n.get("HealthReport"));
+      Assertions.assertNotNull(n.get("NodeManagerVersion"));
+      Assertions.assertNotNull(n.get("NumContainers"));
+      Assertions.assertEquals(
+      
+             0, n.get("NumContainers").asInt(), n.get("NodeId") + ": Unexpected number of used containers");
+      Assertions.assertEquals(
+      
+             0, n.get("UsedMemoryMB").asInt(), n.get("NodeId") + ": Unexpected amount of used memory");
+      Assertions.assertNotNull(n.get("AvailableMemoryMB"));
     }
   }
   
@@ -146,22 +146,22 @@ public class TestRMNMInfo {
     String liveNMs = rmInfo.getLiveNodeManagers();
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jn = mapper.readTree(liveNMs);
-    Assert.assertEquals("Unexpected number of live nodes:",
-                                               1, jn.size());
+    Assertions.assertEquals(
+                                              1, jn.size(), "Unexpected number of live nodes:");
     Iterator<JsonNode> it = jn.iterator();
     while (it.hasNext()) {
       JsonNode n = it.next();
-      Assert.assertNotNull(n.get("HostName"));
-      Assert.assertNotNull(n.get("Rack"));
-      Assert.assertTrue("Node " + n.get("NodeId") + " should be RUNNING",
-              n.get("State").asText().contains("RUNNING"));
-      Assert.assertNotNull(n.get("NodeHTTPAddress"));
-      Assert.assertNotNull(n.get("LastHealthUpdate"));
-      Assert.assertNotNull(n.get("HealthReport"));
-      Assert.assertNotNull(n.get("NodeManagerVersion"));
-      Assert.assertNull(n.get("NumContainers"));
-      Assert.assertNull(n.get("UsedMemoryMB"));
-      Assert.assertNull(n.get("AvailableMemoryMB"));
+      Assertions.assertNotNull(n.get("HostName"));
+      Assertions.assertNotNull(n.get("Rack"));
+      Assertions.assertTrue(
+             n.get("State").asText().contains("RUNNING"), "Node " + n.get("NodeId") + " should be RUNNING");
+      Assertions.assertNotNull(n.get("NodeHTTPAddress"));
+      Assertions.assertNotNull(n.get("LastHealthUpdate"));
+      Assertions.assertNotNull(n.get("HealthReport"));
+      Assertions.assertNotNull(n.get("NodeManagerVersion"));
+      Assertions.assertNull(n.get("NumContainers"));
+      Assertions.assertNull(n.get("UsedMemoryMB"));
+      Assertions.assertNull(n.get("AvailableMemoryMB"));
     }
   }
 }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecOnCluster.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecOnCluster.java
@@ -57,11 +57,11 @@ import org.apache.hadoop.mapreduce.v2.app.speculate.ExponentiallySmoothedTaskRun
 import org.apache.hadoop.mapreduce.v2.app.speculate.LegacyTaskRuntimeEstimator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.SimpleExponentialTaskRuntimeEstimator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.TaskRuntimeEstimator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
@@ -175,7 +175,7 @@ public class TestSpeculativeExecOnCluster {
 
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -203,7 +203,7 @@ public class TestSpeculativeExecOnCluster {
     chosenSleepCalc = MAP_SLEEP_CALCULATOR_TYPE_DEFAULT;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -242,7 +242,7 @@ public class TestSpeculativeExecOnCluster {
       extends InputFormat<IntWritable, IntWritable> {
 
     public List<InputSplit> getSplits(JobContext jobContext) {
-      List<InputSplit> ret = new ArrayList<InputSplit>();
+      List<InputSplit> ret = new ArrayList<>();
       int numSplits = jobContext.getConfiguration().
           getInt(MRJobConfig.NUM_MAPS, 1);
       for (int i = 0; i < numSplits; ++i) {
@@ -641,21 +641,20 @@ public class TestSpeculativeExecOnCluster {
       Job job = runSpecTest();
 
       boolean succeeded = job.waitForCompletion(true);
-      Assert.assertTrue(
-          "Job expected to succeed with estimator " + estimatorClass.getName(),
-          succeeded);
-      Assert.assertEquals(
-          "Job expected to succeed with estimator " + estimatorClass.getName(),
-          JobStatus.State.SUCCEEDED, job.getJobState());
+      Assertions.assertTrue(
+      
+         succeeded, "Job expected to succeed with estimator " + estimatorClass.getName());
+      Assertions.assertEquals(
+      
+         JobStatus.State.SUCCEEDED, job.getJobState(), "Job expected to succeed with estimator " + estimatorClass.getName());
       Counters counters = job.getCounters();
 
       String errorMessage = specEstimator.getErrorMessage(counters);
       boolean didSpeculate = specEstimator.didSpeculate(counters);
-      Assert.assertEquals(errorMessage, didSpeculate,
-          specEstimator.speculativeEstimator);
-      Assert
-          .assertEquals("Failed maps higher than 0 " + estimatorClass.getName(),
-              0, counters.findCounter(JobCounter.NUM_FAILED_MAPS).getValue());
+      Assertions.assertEquals(didSpeculate,
+          specEstimator.speculativeEstimator, errorMessage);
+      Assertions.assertEquals(
+             0, counters.findCounter(JobCounter.NUM_FAILED_MAPS).getValue(), "Failed maps higher than 0 " + estimatorClass.getName());
     }
   }
 
@@ -702,21 +701,20 @@ public class TestSpeculativeExecOnCluster {
       Job job = runSpecTest();
 
       boolean succeeded = job.waitForCompletion(true);
-      Assert.assertTrue(
-          "Job expected to succeed with estimator " + estimatorClass.getName(),
-          succeeded);
-      Assert.assertEquals(
-          "Job expected to succeed with estimator " + estimatorClass.getName(),
-          JobStatus.State.SUCCEEDED, job.getJobState());
+      Assertions.assertTrue(
+      
+         succeeded, "Job expected to succeed with estimator " + estimatorClass.getName());
+      Assertions.assertEquals(
+      
+         JobStatus.State.SUCCEEDED, job.getJobState(), "Job expected to succeed with estimator " + estimatorClass.getName());
       Counters counters = job.getCounters();
 
       String errorMessage = specEstimator.getErrorMessage(counters);
       boolean didSpeculate = specEstimator.didSpeculate(counters);
-      Assert.assertEquals(errorMessage, didSpeculate,
-          specEstimator.speculativeEstimator);
-      Assert
-          .assertEquals("Failed maps higher than 0 " + estimatorClass.getName(),
-              0, counters.findCounter(JobCounter.NUM_FAILED_MAPS).getValue());
+      Assertions.assertEquals(didSpeculate,
+          specEstimator.speculativeEstimator, errorMessage);
+      Assertions.assertEquals(
+          0, counters.findCounter(JobCounter.NUM_FAILED_MAPS).getValue(), "Failed maps higher than 0 " + estimatorClass.getName());
     }
   }
 
@@ -758,21 +756,21 @@ public class TestSpeculativeExecOnCluster {
       Job job = runSpecTest();
 
       boolean succeeded = job.waitForCompletion(true);
-      Assert.assertTrue("Job expected to succeed with estimator "
-          + estimatorClass.getName(), succeeded);
-      Assert.assertEquals("Job expected to succeed with estimator "
-              + estimatorClass.getName(), JobStatus.State.SUCCEEDED,
-          job.getJobState());
+      Assertions.assertTrue(succeeded, "Job expected to succeed with estimator "
+          + estimatorClass.getName());
+      Assertions.assertEquals(JobStatus.State.SUCCEEDED
+,           job.getJobState(), "Job expected to succeed with estimator "
+              + estimatorClass.getName());
       Counters counters = job.getCounters();
 
       String errorMessage = specEstimator.getErrorMessage(counters);
       boolean didSpeculate = specEstimator.didSpeculate(counters);
-      Assert.assertEquals(errorMessage, didSpeculate,
-          specEstimator.speculativeEstimator);
-      Assert.assertEquals("Failed maps higher than 0 "
-              + estimatorClass.getName(), 0,
-          counters.findCounter(JobCounter.NUM_FAILED_MAPS)
-              .getValue());
+      Assertions.assertEquals(didSpeculate,
+          specEstimator.speculativeEstimator, errorMessage);
+      Assertions.assertEquals(0
+,           counters.findCounter(JobCounter.NUM_FAILED_MAPS)
+              .getValue(), "Failed maps higher than 0 "
+              + estimatorClass.getName());
     }
   }
 
@@ -815,21 +813,21 @@ public class TestSpeculativeExecOnCluster {
       Job job = runSpecTest();
 
       boolean succeeded = job.waitForCompletion(true);
-      Assert.assertTrue("Job expected to succeed with estimator "
-          + estimatorClass.getName(), succeeded);
-      Assert.assertEquals("Job expected to succeed with estimator "
-              + estimatorClass.getName(), JobStatus.State.SUCCEEDED,
-          job.getJobState());
+      Assertions.assertTrue(succeeded, "Job expected to succeed with estimator "
+          + estimatorClass.getName());
+      Assertions.assertEquals(JobStatus.State.SUCCEEDED
+,           job.getJobState(), "Job expected to succeed with estimator "
+              + estimatorClass.getName());
       Counters counters = job.getCounters();
 
       String errorMessage = specEstimator.getErrorMessage(counters);
       boolean didSpeculate = specEstimator.didSpeculate(counters);
-      Assert.assertEquals(errorMessage, didSpeculate,
-          specEstimator.speculativeEstimator);
-      Assert.assertEquals("Failed maps higher than 0 "
-              + estimatorClass.getName(), 0,
-          counters.findCounter(JobCounter.NUM_FAILED_MAPS)
-              .getValue());
+      Assertions.assertEquals(didSpeculate,
+          specEstimator.speculativeEstimator, errorMessage);
+      Assertions.assertEquals(0
+,           counters.findCounter(JobCounter.NUM_FAILED_MAPS)
+              .getValue(), "Failed maps higher than 0 "
+              + estimatorClass.getName());
     }
   }
 
@@ -874,17 +872,17 @@ public class TestSpeculativeExecOnCluster {
       Job job = runSpecTest();
 
       boolean succeeded = job.waitForCompletion(true);
-      Assert.assertTrue("Job expected to succeed with estimator "
-          + estimatorClass.getName(), succeeded);
-      Assert.assertEquals("Job expected to succeed with estimator "
-              + estimatorClass.getName(), JobStatus.State.SUCCEEDED,
-          job.getJobState());
+      Assertions.assertTrue(succeeded, "Job expected to succeed with estimator "
+          + estimatorClass.getName());
+      Assertions.assertEquals(JobStatus.State.SUCCEEDED
+,           job.getJobState(), "Job expected to succeed with estimator "
+              + estimatorClass.getName());
       Counters counters = job.getCounters();
 
       String errorMessage = specEstimator.getErrorMessage(counters);
       boolean didSpeculate = specEstimator.didSpeculate(counters);
-      Assert.assertEquals(errorMessage, didSpeculate,
-          specEstimator.speculativeEstimator);
+      Assertions.assertEquals(didSpeculate,
+          specEstimator.speculativeEstimator, errorMessage);
     }
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecution.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecution.java
@@ -42,10 +42,10 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskAttemptId;
 import org.apache.hadoop.mapreduce.v2.app.speculate.LegacyTaskRuntimeEstimator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.TaskRuntimeEstimator;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +103,7 @@ public class TestSpeculativeExecution {
   static Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
   private static Path TEST_OUT_DIR = new Path(TEST_ROOT_DIR, "test.out.dir");
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
 
     if (!(new File(MiniMRYarnCluster.APPJAR)).exists()) {
@@ -124,7 +124,7 @@ public class TestSpeculativeExecution {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrCluster != null) {
       mrCluster.stop();
@@ -248,14 +248,14 @@ public class TestSpeculativeExecution {
     Job job = runSpecTest(false, false);
 
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
     Counters counters = job.getCounters();
-    Assert.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
             .getValue());
-    Assert.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
             .getValue());
-    Assert.assertEquals(0, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
+    Assertions.assertEquals(0, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
             .getValue());
 
 
@@ -268,18 +268,18 @@ public class TestSpeculativeExecution {
     job = runNonSpecFailOnceTest();
 
     succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
     counters = job.getCounters();
     // We will have 4 total since 2 map tasks fail and relaunch attempt once
-    Assert.assertEquals(4,
+    Assertions.assertEquals(4,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS).getValue());
-    Assert.assertEquals(4,
+    Assertions.assertEquals(4,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES).getValue());
     // Ensure no maps or reduces killed due to accidental speculation
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         counters.findCounter(JobCounter.NUM_KILLED_MAPS).getValue());
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         counters.findCounter(JobCounter.NUM_KILLED_REDUCES).getValue());
 
     /*----------------------------------------------------------------------
@@ -290,18 +290,18 @@ public class TestSpeculativeExecution {
     job = runSpecTest(true, false);
 
     succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
     counters = job.getCounters();
 
     // The long-running map will be killed and a new one started.
-    Assert.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
             .getValue());
-    Assert.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
             .getValue());
-    Assert.assertEquals(0, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
+    Assertions.assertEquals(0, counters.findCounter(JobCounter.NUM_FAILED_MAPS)
             .getValue());
-    Assert.assertEquals(1, counters.findCounter(JobCounter.NUM_KILLED_MAPS)
+    Assertions.assertEquals(1, counters.findCounter(JobCounter.NUM_KILLED_MAPS)
         .getValue());
 
     /*----------------------------------------------------------------------
@@ -312,14 +312,14 @@ public class TestSpeculativeExecution {
     job = runSpecTest(false, true);
 
     succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    Assertions.assertTrue(succeeded);
+    Assertions.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
     counters = job.getCounters();
 
     // The long-running map will be killed and a new one started.
-    Assert.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.TOTAL_LAUNCHED_MAPS)
             .getValue());
-    Assert.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.TOTAL_LAUNCHED_REDUCES)
             .getValue());
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecutionWithMRApp.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestSpeculativeExecutionWithMRApp.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.v2.app.speculate.LegacyTaskRuntimeEstimator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.SimpleExponentialTaskRuntimeEstimator;
 import org.apache.hadoop.mapreduce.v2.app.speculate.TaskRuntimeEstimator;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.v2.api.records.JobState;
 import org.apache.hadoop.mapreduce.v2.api.records.TaskAttemptId;
@@ -48,8 +48,9 @@ import org.apache.hadoop.service.Service;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.ControlledClock;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -91,7 +92,7 @@ public class TestSpeculativeExecutionWithMRApp {
     this.controlledClk = new ControlledClock();
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     this.controlledClk.setTime(System.currentTimeMillis());
   }
@@ -101,7 +102,8 @@ public class TestSpeculativeExecutionWithMRApp {
    *
    * @throws Exception the exception
    */
-  @Test (timeout = 360000)
+  @Test
+  @Timeout(value = 360)
   public void testSpeculateSuccessfulWithoutUpdateEvents() throws Exception {
     MRApp app =
         new MRApp(NUM_MAPPERS, NUM_REDUCERS, false, "test", true,
@@ -110,8 +112,8 @@ public class TestSpeculativeExecutionWithMRApp {
     app.waitForState(job, JobState.RUNNING);
 
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", NUM_MAPPERS + NUM_REDUCERS,
-      tasks.size());
+    Assertions.assertEquals(NUM_MAPPERS + NUM_REDUCERS
+,       tasks.size(), "Num tasks is not correct");
     Iterator<Task> taskIter = tasks.values().iterator();
     while (taskIter.hasNext()) {
       app.waitForState(taskIter.next(), TaskState.RUNNING);
@@ -161,7 +163,8 @@ public class TestSpeculativeExecutionWithMRApp {
    *
    * @throws Exception the exception
    */
-  @Test (timeout = 360000)
+  @Test
+  @Timeout(value = 360)
   public void testSpeculateSuccessfulWithUpdateEvents() throws Exception {
     MRApp app =
         new MRApp(NUM_MAPPERS, NUM_REDUCERS, false, "test", true,
@@ -170,8 +173,8 @@ public class TestSpeculativeExecutionWithMRApp {
     app.waitForState(job, JobState.RUNNING);
 
     Map<TaskId, Task> tasks = job.getTasks();
-    Assert.assertEquals("Num tasks is not correct", NUM_MAPPERS + NUM_REDUCERS,
-      tasks.size());
+    Assertions.assertEquals(NUM_MAPPERS + NUM_REDUCERS
+,       tasks.size(), "Num tasks is not correct");
     Iterator<Task> taskIter = tasks.values().iterator();
     while (taskIter.hasNext()) {
       app.waitForState(taskIter.next(), TaskState.RUNNING);

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/mapreduce/v2/TestUberAM.java
@@ -30,9 +30,9 @@ import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskCompletionEvent;
 import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,7 @@ public class TestUberAM extends TestMRJobs {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestUberAM.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     TestMRJobs.setup();
     if (mrCluster != null) {
@@ -71,11 +71,11 @@ public class TestUberAM extends TestMRJobs {
       IOException {
     Counters counters = job.getCounters();
     super.verifySleepJobCounters(job);
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         counters.findCounter(JobCounter.NUM_UBER_SUBMAPS).getValue());
-    Assert.assertEquals(numSleepReducers,
+    Assertions.assertEquals(numSleepReducers,
         counters.findCounter(JobCounter.NUM_UBER_SUBREDUCES).getValue());
-    Assert.assertEquals(3 + numSleepReducers,
+    Assertions.assertEquals(3 + numSleepReducers,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_UBERTASKS).getValue());
   }
 
@@ -91,9 +91,9 @@ public class TestUberAM extends TestMRJobs {
       throws InterruptedException, IOException {
     super.verifyRandomWriterCounters(job);
     Counters counters = job.getCounters();
-    Assert.assertEquals(3, counters.findCounter(JobCounter.NUM_UBER_SUBMAPS)
+    Assertions.assertEquals(3, counters.findCounter(JobCounter.NUM_UBER_SUBMAPS)
         .getValue());
-    Assert.assertEquals(3,
+    Assertions.assertEquals(3,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_UBERTASKS).getValue());
   }
 
@@ -132,12 +132,12 @@ public class TestUberAM extends TestMRJobs {
     assertThat(secondTaskAttemptExists).isFalse();
 
     TaskCompletionEvent[] events = job.getTaskCompletionEvents(0, 2);
-    Assert.assertEquals(1, events.length);
+    Assertions.assertEquals(1, events.length);
     // TIPFAILED if it comes from the AM, FAILED if it comes from the JHS
     TaskCompletionEvent.Status status = events[0].getStatus();
-    Assert.assertTrue(status == TaskCompletionEvent.Status.FAILED ||
+    Assertions.assertTrue(status == TaskCompletionEvent.Status.FAILED ||
         status == TaskCompletionEvent.Status.TIPFAILED);
-    Assert.assertEquals(JobStatus.State.FAILED, job.getJobState());
+    Assertions.assertEquals(JobStatus.State.FAILED, job.getJobState());
     
     //Disabling till UberAM honors MRJobConfig.MAP_MAX_ATTEMPTS
     //verifyFailingMapperCounters(job);
@@ -150,11 +150,11 @@ public class TestUberAM extends TestMRJobs {
       throws InterruptedException, IOException {
     Counters counters = job.getCounters();
     super.verifyFailingMapperCounters(job);
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         counters.findCounter(JobCounter.TOTAL_LAUNCHED_UBERTASKS).getValue());
-    Assert.assertEquals(2, counters.findCounter(JobCounter.NUM_UBER_SUBMAPS)
+    Assertions.assertEquals(2, counters.findCounter(JobCounter.NUM_UBER_SUBMAPS)
         .getValue());
-    Assert.assertEquals(2, counters
+    Assertions.assertEquals(2, counters
         .findCounter(JobCounter.NUM_FAILED_UBERTASKS).getValue());
   }
 

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/util/TestMRCJCReflectionUtils.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/util/TestMRCJCReflectionUtils.java
@@ -22,16 +22,16 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobConfigurable;
 
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the JobConf-related parts of common's ReflectionUtils
  * class.
  */
 public class TestMRCJCReflectionUtils {
-  @Before
+  @BeforeEach
   public void setUp() {
     ReflectionUtils.clearCache();
   }

--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/util/TestMRCJCRunJar.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/test/java/org/apache/hadoop/util/TestMRCJCRunJar.java
@@ -27,8 +27,8 @@ import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test to rest the RunJar class.
@@ -55,7 +55,7 @@ public class TestMRCJCRunJar {
     args[1] = "org.apache.hadoop.util.Hello";
     args[2] = outFile.toString();
     RunJar.main(args);
-    Assert.assertTrue("RunJar failed", outFile.exists());
+    Assertions.assertTrue(outFile.exists(), "RunJar failed");
   }
 
   private File makeTestJar() throws IOException {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: MAPREDUCE-7421. Upgrade Junit 4 to 5 in hadoop-mapreduce-client-jobclient.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

