### PR TITLE
YARN-11243. Upgrade JUnit from 4 to 5 in hadoop-yarn-applications.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/DistributedShellBaseTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/DistributedShellBaseTest.java
@@ -34,11 +34,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
@@ -117,7 +117,7 @@ public abstract class DistributedShellBaseTest {
   // location of the filesystem timeline writer for timeline service v.2
   private String timelineV2StorageDir = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupUnitTests() throws Exception {
     URL url = Thread.currentThread().getContextClassLoader().getResource(
         "yarn-site.xml");
@@ -134,7 +134,7 @@ public abstract class DistributedShellBaseTest {
         StandardCopyOption.REPLACE_EXISTING);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownUnitTests() throws Exception {
     // shutdown the clusters.
     shutdownYarnCluster();
@@ -215,12 +215,12 @@ public abstract class DistributedShellBaseTest {
     timelineV2StorageDir = tmpFolder.newFolder().getAbsolutePath();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     setupInternal(NUM_NMS, new YarnConfiguration());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     cleanUpDFSClient();
     FileContext fsContext = FileContext.getLocalFSFileContext();
@@ -329,7 +329,7 @@ public abstract class DistributedShellBaseTest {
     YarnClient yarnClient;
     dsClient = setAndGetDSClient(new Configuration(yarnCluster.getConfig()));
     boolean initSuccess = dsClient.init(args);
-    Assert.assertTrue(initSuccess);
+    Assertions.assertTrue(initSuccess);
     LOG.info("Running DS Client");
     final AtomicBoolean result = new AtomicBoolean(false);
     Thread t = new Thread(() -> {
@@ -379,11 +379,11 @@ public abstract class DistributedShellBaseTest {
     t.join();
     if (waitResult.get() == 2) {
       // Exception was raised
-      Assert.fail("Exception in getting application report. Failed");
+      Assertions.fail("Exception in getting application report. Failed");
     }
     if (waitResult.get() == 1) {
-      Assert.assertEquals("Failed waiting for expected rpc port to be -1.",
-          -1, appReportRef.get().getRpcPort());
+      Assertions.assertEquals(
+         -1, appReportRef.get().getRpcPort(), "Failed waiting for expected rpc port to be -1.");
     }
     checkTimeline(appIdRef.get(), defaultFlow, haveDomain, appReportRef.get());
   }
@@ -399,22 +399,22 @@ public abstract class DistributedShellBaseTest {
     if (haveDomain) {
       domain = yarnCluster.getApplicationHistoryServer()
           .getTimelineStore().getDomain("TEST_DOMAIN");
-      Assert.assertNotNull(domain);
-      Assert.assertEquals("reader_user reader_group", domain.getReaders());
-      Assert.assertEquals("writer_user writer_group", domain.getWriters());
+      Assertions.assertNotNull(domain);
+      Assertions.assertEquals("reader_user reader_group", domain.getReaders());
+      Assertions.assertEquals("writer_user writer_group", domain.getWriters());
     }
     TimelineEntities entitiesAttempts = yarnCluster
         .getApplicationHistoryServer()
         .getTimelineStore()
         .getEntities(ApplicationMaster.DSEntity.DS_APP_ATTEMPT.toString(),
             null, null, null, null, null, null, null, null, null);
-    Assert.assertNotNull(entitiesAttempts);
-    Assert.assertEquals(1, entitiesAttempts.getEntities().size());
-    Assert.assertEquals(2, entitiesAttempts.getEntities().get(0).getEvents()
+    Assertions.assertNotNull(entitiesAttempts);
+    Assertions.assertEquals(1, entitiesAttempts.getEntities().size());
+    Assertions.assertEquals(2, entitiesAttempts.getEntities().get(0).getEvents()
         .size());
-    Assert.assertEquals(entitiesAttempts.getEntities().get(0).getEntityType(),
+    Assertions.assertEquals(entitiesAttempts.getEntities().get(0).getEntityType(),
         ApplicationMaster.DSEntity.DS_APP_ATTEMPT.toString());
-    Assert.assertEquals(haveDomain ? domain.getId() : "DEFAULT",
+    Assertions.assertEquals(haveDomain ? domain.getId() : "DEFAULT",
         entitiesAttempts.getEntities().get(0).getDomainId());
     String currAttemptEntityId =
         entitiesAttempts.getEntities().get(0).getEntityId();
@@ -428,9 +428,9 @@ public abstract class DistributedShellBaseTest {
         .getTimelineStore()
         .getEntities(ApplicationMaster.DSEntity.DS_CONTAINER.toString(), null,
             null, null, null, null, primaryFilter, null, null, null);
-    Assert.assertNotNull(entities);
-    Assert.assertEquals(2, entities.getEntities().size());
-    Assert.assertEquals(entities.getEntities().get(0).getEntityType(),
+    Assertions.assertNotNull(entities);
+    Assertions.assertEquals(2, entities.getEntities().size());
+    Assertions.assertEquals(entities.getEntities().get(0).getEntityType(),
         ApplicationMaster.DSEntity.DS_CONTAINER.toString());
 
     String entityId = entities.getEntities().get(0).getEntityId();
@@ -438,9 +438,9 @@ public abstract class DistributedShellBaseTest {
         yarnCluster.getApplicationHistoryServer().getTimelineStore()
             .getEntity(entityId,
                 ApplicationMaster.DSEntity.DS_CONTAINER.toString(), null);
-    Assert.assertNotNull(entity);
-    Assert.assertEquals(entityId, entity.getEntityId());
-    Assert.assertEquals(haveDomain ? domain.getId() : "DEFAULT",
+    Assertions.assertNotNull(entity);
+    Assertions.assertEquals(entityId, entity.getEntityId());
+    Assertions.assertEquals(haveDomain ? domain.getId() : "DEFAULT",
         entities.getEntities().get(0).getDomainId());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestClient.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.yarn.applications.distributedshell;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestClient {
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSAppMaster.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSAppMaster.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.timelineservice.storage.FileSystemTimelineWriterImpl;
 import org.apache.hadoop.yarn.server.timelineservice.storage.TimelineWriter;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -105,12 +105,12 @@ public class TestDSAppMaster {
 
     // first allocate a single container, everything should be fine
     handler.onContainersAllocated(containers);
-    Assert.assertEquals("Wrong container allocation count", 1,
-        master.getAllocatedContainers());
-    Assert.assertEquals("Incorrect number of threads launched", 1,
-        master.threadsLaunched);
-    Assert.assertEquals("Incorrect YARN Shell IDs",
-        Arrays.asList("1"), master.yarnShellIds);
+    Assertions.assertEquals(1
+,         master.getAllocatedContainers(), "Wrong container allocation count");
+    Assertions.assertEquals(1
+,         master.threadsLaunched, "Incorrect number of threads launched");
+    Assertions.assertEquals(
+       Arrays.asList("1"), master.yarnShellIds, "Incorrect YARN Shell IDs");
 
     // now send 3 extra containers
     containers.clear();
@@ -121,14 +121,14 @@ public class TestDSAppMaster {
     ContainerId id4 = BuilderUtils.newContainerId(1, 1, 1, 4);
     containers.add(generateContainer(id4));
     handler.onContainersAllocated(containers);
-    Assert.assertEquals("Wrong final container allocation count", 2,
-        master.getAllocatedContainers());
+    Assertions.assertEquals(2
+,         master.getAllocatedContainers(), "Wrong final container allocation count");
 
-    Assert.assertEquals("Incorrect number of threads launched", 2,
-        master.threadsLaunched);
+    Assertions.assertEquals(2
+,         master.threadsLaunched, "Incorrect number of threads launched");
 
-    Assert.assertEquals("Incorrect YARN Shell IDs",
-        Arrays.asList("1", "2"), master.yarnShellIds);
+    Assertions.assertEquals(
+       Arrays.asList("1", "2"), master.yarnShellIds, "Incorrect YARN Shell IDs");
     // make sure we handle completion events correctly
     List<ContainerStatus> status = new ArrayList<>();
     status.add(generateContainerStatus(id1, ContainerExitStatus.SUCCESS));
@@ -137,25 +137,25 @@ public class TestDSAppMaster {
     status.add(generateContainerStatus(id4, ContainerExitStatus.ABORTED));
     handler.onContainersCompleted(status);
 
-    Assert.assertEquals("Unexpected number of completed containers",
-        targetContainers, master.getNumCompletedContainers());
-    Assert.assertTrue("Master didn't finish containers as expected",
-        master.getDone());
+    Assertions.assertEquals(
+       targetContainers, master.getNumCompletedContainers(), "Unexpected number of completed containers");
+    Assertions.assertTrue(
+       master.getDone(), "Master didn't finish containers as expected");
 
     // test for events from containers we know nothing about
     // these events should be ignored
     status = new ArrayList<>();
     ContainerId id5 = BuilderUtils.newContainerId(1, 1, 1, 5);
     status.add(generateContainerStatus(id5, ContainerExitStatus.ABORTED));
-    Assert.assertEquals("Unexpected number of completed containers",
-        targetContainers, master.getNumCompletedContainers());
-    Assert.assertTrue("Master didn't finish containers as expected",
-        master.getDone());
+    Assertions.assertEquals(
+       targetContainers, master.getNumCompletedContainers(), "Unexpected number of completed containers");
+    Assertions.assertTrue(
+       master.getDone(), "Master didn't finish containers as expected");
     status.add(generateContainerStatus(id5, ContainerExitStatus.SUCCESS));
-    Assert.assertEquals("Unexpected number of completed containers",
-        targetContainers, master.getNumCompletedContainers());
-    Assert.assertTrue("Master didn't finish containers as expected",
-        master.getDone());
+    Assertions.assertEquals(
+       targetContainers, master.getNumCompletedContainers(), "Unexpected number of completed containers");
+    Assertions.assertTrue(
+       master.getDone(), "Master didn't finish containers as expected");
   }
 
   private Container generateContainer(ContainerId cid) {
@@ -200,15 +200,15 @@ public class TestDSAppMaster {
   private void validateAppMasterTimelineService(boolean v1Enabled,
       boolean v2Enabled, ApplicationMaster appMaster) {
     if (v1Enabled) {
-      Assert.assertEquals(appMaster.appSubmitterUgi,
+      Assertions.assertEquals(appMaster.appSubmitterUgi,
           ((TimelineClientImpl)appMaster.timelineClient).getUgi());
     } else {
-      Assert.assertNull(appMaster.timelineClient);
+      Assertions.assertNull(appMaster.timelineClient);
     }
     if (v2Enabled) {
-      Assert.assertNotNull(appMaster.timelineV2Client);
+      Assertions.assertNotNull(appMaster.timelineV2Client);
     } else {
-      Assert.assertNull(appMaster.timelineV2Client);
+      Assertions.assertNull(appMaster.timelineV2Client);
     }
   }
 
@@ -227,7 +227,7 @@ public class TestDSAppMaster {
   private Configuration getTimelineServiceConf(boolean v1Enabled,
       boolean v2Enabled) {
     Configuration conf = new YarnConfiguration(new Configuration(false));
-    Assert.assertFalse(YarnConfiguration.timelineServiceEnabled(conf));
+    Assertions.assertFalse(YarnConfiguration.timelineServiceEnabled(conf));
 
     if (v1Enabled || v2Enabled) {
       conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV10.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV10.java
@@ -35,8 +35,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.jodah.failsafe.RetryPolicy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,9 +65,7 @@ import org.apache.hadoop.yarn.util.Records;
 
 import javax.ws.rs.ProcessingException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -123,7 +121,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     boolean result = getDSClient().run();
     LOG.info("Client run completed. Result={}", result);
     // application should succeed
-    Assert.assertTrue(result);
+    Assertions.assertTrue(result);
   }
 
   /*
@@ -160,7 +158,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     LOG.info("Client run completed. Result = {}.", result);
     // application should succeed
-    Assert.assertTrue(result);
+    Assertions.assertTrue(result);
   }
 
   /*
@@ -197,7 +195,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     LOG.info("Client run completed. Result=" + result);
     // application should be failed
-    Assert.assertFalse(result);
+    Assertions.assertFalse(result);
   }
 
   @Test
@@ -210,7 +208,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
       customLogProperty.delete();
     }
     if (!customLogProperty.createNewFile()) {
-      Assert.fail("Can not create custom log4j property file.");
+      Assertions.fail("Can not create custom log4j property file.");
     }
     PrintWriter fileWriter = new PrintWriter(customLogProperty);
     // set the output to DEBUG level
@@ -238,26 +236,26 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     // Before run the DS, the default the log level is INFO
     final Logger LOG_Client =
         LoggerFactory.getLogger(Client.class);
-    Assert.assertTrue(LOG_Client.isInfoEnabled());
-    Assert.assertFalse(LOG_Client.isDebugEnabled());
+    Assertions.assertTrue(LOG_Client.isInfoEnabled());
+    Assertions.assertFalse(LOG_Client.isDebugEnabled());
     final Logger LOG_AM = LoggerFactory.getLogger(ApplicationMaster.class);
-    Assert.assertTrue(LOG_AM.isInfoEnabled());
-    Assert.assertFalse(LOG_AM.isDebugEnabled());
+    Assertions.assertTrue(LOG_AM.isInfoEnabled());
+    Assertions.assertFalse(LOG_AM.isDebugEnabled());
 
     LOG.info("Initializing DS Client");
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
     boolean initSuccess = getDSClient().init(args);
-    Assert.assertTrue(initSuccess);
+    Assertions.assertTrue(initSuccess);
 
     LOG.info("Running DS Client");
     boolean result = getDSClient().run();
     LOG.info("Client run completed. Result=" + result);
-    Assert.assertTrue(verifyContainerLog(3, null, true, "DEBUG") > 10);
+    Assertions.assertTrue(verifyContainerLog(3, null, true, "DEBUG") > 10);
     //After DS is finished, the log level should be DEBUG
-    Assert.assertTrue(LOG_Client.isInfoEnabled());
-    Assert.assertTrue(LOG_Client.isDebugEnabled());
-    Assert.assertTrue(LOG_AM.isInfoEnabled());
-    Assert.assertTrue(LOG_AM.isDebugEnabled());
+    Assertions.assertTrue(LOG_Client.isInfoEnabled());
+    Assertions.assertTrue(LOG_Client.isDebugEnabled());
+    Assertions.assertTrue(LOG_AM.isInfoEnabled());
+    Assertions.assertTrue(LOG_AM.isDebugEnabled());
   }
 
   @Test
@@ -270,7 +268,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
         regex
     );
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    Assert.assertTrue(getDSClient().init(args));
+    Assertions.assertTrue(getDSClient().init(args));
 
     ApplicationSubmissionContext context =
         Records.newRecord(ApplicationSubmissionContext.class);
@@ -302,7 +300,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     LOG.info("Initializing DS Client");
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
     boolean initSuccess = getDSClient().init(args);
-    Assert.assertTrue(initSuccess);
+    Assertions.assertTrue(initSuccess);
     LOG.info("Running DS Client");
 
     boolean result = getDSClient().run();
@@ -322,7 +320,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
       customShellScript.delete();
     }
     if (!customShellScript.createNewFile()) {
-      Assert.fail("Can not create custom shell script file.");
+      Assertions.fail("Can not create custom shell script file.");
     }
     PrintWriter fileWriter = new PrintWriter(customShellScript);
     // set the output to DEBUG level
@@ -346,7 +344,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     LOG.info("Initializing DS Client");
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    Assert.assertTrue(getDSClient().init(args));
+    Assertions.assertTrue(getDSClient().init(args));
     LOG.info("Running DS Client");
     assertTrue(getDSClient().run());
     List<String> expectedContent = new ArrayList<>();
@@ -579,9 +577,9 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     LOG.info("Initializing DS Client");
     setAndGetDSClient(ContainerLaunchFailAppMaster.class.getName(),
         new Configuration(getYarnClusterConfiguration()));
-    Assert.assertTrue(getDSClient().init(args));
+    Assertions.assertTrue(getDSClient().init(args));
     LOG.info("Running DS Client");
-    Assert.assertFalse(getDSClient().run());
+    Assertions.assertFalse(getDSClient().run());
   }
 
   @Test
@@ -604,9 +602,9 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     LOG.info("Initializing DS Client");
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    Assert.assertTrue(getDSClient().init(args));
+    Assertions.assertTrue(getDSClient().init(args));
     LOG.info("Running DS Client");
-    Assert.assertTrue(getDSClient().run());
+    Assertions.assertTrue(getDSClient().run());
   }
 
   private int verifyContainerLog(int containerNum,
@@ -617,7 +615,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
                 YarnConfiguration.DEFAULT_NM_LOG_DIRS));
 
     File[] listOfFiles = logFolder.listFiles();
-    Assert.assertNotNull(listOfFiles);
+    Assertions.assertNotNull(listOfFiles);
     int currentContainerLogFileIndex = -1;
     for (int i = listOfFiles.length - 1; i >= 0; i--) {
       if (listOfFiles[i].listFiles().length == containerNum + 1) {
@@ -625,7 +623,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
         break;
       }
     }
-    Assert.assertTrue(currentContainerLogFileIndex != -1);
+    Assertions.assertTrue(currentContainerLogFileIndex != -1);
     File[] containerFiles =
         listOfFiles[currentContainerLogFileIndex].listFiles();
 
@@ -648,8 +646,8 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
                 }
               } else if (output.getName().trim().equals("stdout")) {
                 if (!Shell.WINDOWS) {
-                  Assert.assertEquals("The current is" + sCurrentLine,
-                      expectedContent.get(numOffline), sCurrentLine.trim());
+                  Assertions.assertEquals(
+                     expectedContent.get(numOffline), sCurrentLine.trim(), "The current is" + sCurrentLine);
                   numOffline++;
                 } else {
                   stdOutContent.add(sCurrentLine.trim());
@@ -664,7 +662,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
              */
             if (Shell.WINDOWS && !count
                 && output.getName().trim().equals("stdout")) {
-              Assert.assertTrue(stdOutContent.containsAll(expectedContent));
+              Assertions.assertTrue(stdOutContent.containsAll(expectedContent));
             }
           } catch (IOException e) {
             LOG.error("Exception reading the buffer", e);
@@ -696,7 +694,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     for (int i = 0; i < args.length; ++i) {
       LOG.info("Initializing DS Client[{}]", i);
       setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-      Assert.assertTrue(getDSClient().init(args[i]));
+      Assertions.assertTrue(getDSClient().init(args[i]));
       LOG.info("Running DS Client[{}]", i);
       LambdaTestUtils.intercept(Exception.class,
           () -> getDSClient().run());
@@ -727,36 +725,39 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
     assertTrue(getDSClient().run());
   }
 
-  @Test(expected = ResourceNotFoundException.class)
+  @Test
   public void testDistributedShellAMResourcesWithUnknownResource()
       throws Exception {
-    String[] args = createArgumentsWithAppName(
-        "--num_containers",
-        "1",
-        "--shell_command",
-        getListCommand(),
-        "--master_resources",
-        "unknown-resource=5"
-    );
-    setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    assertTrue(getDSClient().init(args));
-    getDSClient().run();
+    assertThrows(ResourceNotFoundException.class, () -> {
+      String[] args = createArgumentsWithAppName(
+              "--num_containers",
+              "1",
+              "--shell_command",
+              getListCommand(),
+              "--master_resources",
+              "unknown-resource=5"
+      );
+      setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
+      assertTrue(getDSClient().init(args));
+      getDSClient().run();
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testDistributedShellNonExistentQueue()
-      throws Exception {
-    String[] args = createArgumentsWithAppName(
-        "--num_containers",
-        "1",
-        "--shell_command",
-        getListCommand(),
-        "--queue",
-        "non-existent-queue"
-    );
-    setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    assertTrue(getDSClient().init(args));
-    getDSClient().run();
+  @Test
+  public void testDistributedShellNonExistentQueue() throws Exception {
+    assertThrows(IllegalArgumentException.class, () -> {
+      String[] args = createArgumentsWithAppName(
+          "--num_containers",
+          "1",
+          "--shell_command",
+          getListCommand(),
+          "--queue",
+          "non-existent-queue"
+      );
+      setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
+      assertTrue(getDSClient().init(args));
+      getDSClient().run();
+    });
   }
 
   @Test
@@ -775,7 +776,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
     assertTrue(getDSClient().init(args));
-    assertTrue("Client exited with an error", getDSClient().run());
+    assertTrue(getDSClient().run(), "Client exited with an error");
   }
 
   @Test
@@ -794,26 +795,27 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
 
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
     assertTrue(getDSClient().init(args));
-    assertTrue("Client exited with an error", getDSClient().run());
+    assertTrue(getDSClient().run(), "Client exited with an error");
   }
 
-  @Test(expected = UncheckedIOException.class)
+  @Test
   public void testDistributedShellWithNonExistentFileLocalization()
       throws Exception {
-    String[] args = createArgumentsWithAppName(
-        "--num_containers",
-        "1",
-        "--shell_command",
-        getCatCommand(),
-        "--localize_files",
-        "/non/existing/path/file.txt",
-        "--shell_args",
-        "file.txt"
-    );
-
-    setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    assertTrue(getDSClient().init(args));
-    assertTrue(getDSClient().run());
+    assertThrows(UncheckedIOException.class, () -> {
+      String[] args = createArgumentsWithAppName(
+              "--num_containers",
+              "1",
+              "--shell_command",
+              getCatCommand(),
+              "--localize_files",
+              "/non/existing/path/file.txt",
+              "--shell_args",
+              "file.txt"
+      );
+      setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
+      assertTrue(getDSClient().init(args));
+      assertTrue(getDSClient().run());
+    });
   }
 
   @Test
@@ -845,7 +847,7 @@ public class TestDSTimelineV10 extends DistributedShellBaseTest {
       }
     }, 10, 60000);
 
-    assertFalse("Distributed Shell Cleanup failed", fs1.exists(path));
+    assertFalse(fs1.exists(path), "Distributed Shell Cleanup failed");
   }
 
   @Override

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV15.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV15.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.yarn.applications.distributedshell;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,8 +83,8 @@ public class TestDSTimelineV15 extends DistributedShellBaseTest {
         return true;
       }
     }, scanInterval * 2, TEST_TIME_WINDOW_EXPIRE);
-    Assert.assertNull("Exception in getting listing status",
-        exceptionRef.get());
+    Assertions.assertNull(
+       exceptionRef.get(), "Exception in getting listing status");
     super.checkTimeline(appId, defaultFlow, haveDomain, appReport);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV20.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSTimelineV20.java
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,18 +137,18 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
       waitForContainersLaunch(yarnClient, 3, appAttemptReportRef,
           containersListRef, appAttemptIdRef, thrownError);
       if (thrownError.get() != null) {
-        Assert.fail(thrownError.get().getMessage());
+        Assertions.fail(thrownError.get().getMessage());
       }
       ContainerId amContainerId = appAttemptReportRef.get().getAMContainerId();
       for (ContainerReport container : containersListRef.get()) {
         if (!container.getContainerId().equals(amContainerId)) {
-          Assert.assertEquals(container.getExecutionType(),
+          Assertions.assertEquals(container.getExecutionType(),
               ExecutionType.OPPORTUNISTIC);
         }
       }
     } catch (Exception e) {
       LOG.error("Job execution with enforce execution type failed.", e);
-      Assert.fail("Exception. " + e.getMessage());
+      Assertions.fail("Exception. " + e.getMessage());
     } finally {
       if (yarnClient != null) {
         yarnClient.stop();
@@ -209,7 +209,7 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
 
     LOG.info("Initializing DS Client");
     setAndGetDSClient(new Configuration(getYarnClusterConfiguration()));
-    Assert.assertTrue(getDSClient().init(args));
+    Assertions.assertTrue(getDSClient().init(args));
     LOG.info("Running DS Client");
     final AtomicBoolean result = new AtomicBoolean(false);
     Thread dsClientRunner = new Thread(() -> {
@@ -228,19 +228,19 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
       waitForContainersLaunch(yarnClient, 2, appAttemptReportRef,
           containersListRef, appAttemptIdRef, thrownExceptionRef);
       if (thrownExceptionRef.get() != null) {
-        Assert.fail(thrownExceptionRef.get().getMessage());
+        Assertions.fail(thrownExceptionRef.get().getMessage());
       }
       ContainerId amContainerId = appAttemptReportRef.get().getAMContainerId();
       ContainerReport report = yarnClient.getContainerReport(amContainerId);
       Resource masterResource = report.getAllocatedResource();
-      Assert.assertEquals(memVars[0], masterResource.getMemorySize());
-      Assert.assertEquals(1, masterResource.getVirtualCores());
+      Assertions.assertEquals(memVars[0], masterResource.getMemorySize());
+      Assertions.assertEquals(1, masterResource.getVirtualCores());
       for (ContainerReport container : containersListRef.get()) {
         if (!container.getContainerId().equals(amContainerId)) {
           Resource containerResource = container.getAllocatedResource();
-          Assert.assertEquals(memVars[1],
+          Assertions.assertEquals(memVars[1],
               containerResource.getMemorySize());
-          Assert.assertEquals(1, containerResource.getVirtualCores());
+          Assertions.assertEquals(1, containerResource.getVirtualCores());
         }
       }
     } finally {
@@ -294,7 +294,7 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
 
     File tmpRootFolder = new File(tmpRoot);
     try {
-      Assert.assertTrue(tmpRootFolder.isDirectory());
+      Assertions.assertTrue(tmpRootFolder.isDirectory());
       String basePath = tmpRoot +
           YarnConfiguration.DEFAULT_RM_CLUSTER_ID + File.separator +
           UserGroupInformation.getCurrentUser().getShortUserName() +
@@ -436,21 +436,21 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
             TimelineEntity entity = FileSystemTimelineReaderImpl.
                 getTimelineRecordFromJSON(entityLine, TimelineEntity.class);
             TimelineEvent event = entity.getEvents().pollFirst();
-            Assert.assertNotNull(event);
-            Assert.assertTrue("diagnostics",
-                event.getInfo().containsKey(ApplicationMaster.DIAGNOSTICS));
+            Assertions.assertNotNull(event);
+            Assertions.assertTrue(
+               event.getInfo().containsKey(ApplicationMaster.DIAGNOSTICS), "diagnostics");
           }
           if (checkIdPrefix) {
             TimelineEntity entity = FileSystemTimelineReaderImpl.
                 getTimelineRecordFromJSON(entityLine, TimelineEntity.class);
-            Assert.assertTrue("Entity ID prefix expected to be > 0",
-                entity.getIdPrefix() > 0);
+            Assertions.assertTrue(
+               entity.getIdPrefix() > 0, "Entity ID prefix expected to be > 0");
             if (idPrefix == -1) {
               idPrefix = entity.getIdPrefix();
             } else {
-              Assert.assertEquals(
-                  "Entity ID prefix should be same across each publish of "
-                      + "same entity", idPrefix, entity.getIdPrefix());
+              Assertions.assertEquals(
+              idPrefix, entity.getIdPrefix(), "Entity ID prefix should be same across each publish of "
+                      + "same entity");
             }
           }
         }
@@ -463,7 +463,7 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
     }, sleepTime, (checkTimes + 1) * sleepTime);
 
     if (thrownExceptionRef.get() != null) {
-      Assert.fail("verifyEntityForTimeline failed "
+      Assertions.fail("verifyEntityForTimeline failed "
           + thrownExceptionRef.get().getMessage());
     }
   }
@@ -475,10 +475,10 @@ public class TestDSTimelineV20 extends DistributedShellBaseTest {
     LOG.info("verifyEntityTypeFileExists output path for entityType {}: {}",
         entityType, outputDirPathForEntity);
     File outputDirForEntity = new File(outputDirPathForEntity);
-    Assert.assertTrue(outputDirForEntity.isDirectory());
+    Assertions.assertTrue(outputDirForEntity.isDirectory());
     String entityFilePath = outputDirPathForEntity + entityFileName;
     File entityFile = new File(entityFilePath);
-    Assert.assertTrue(entityFile.exists());
+    Assertions.assertTrue(entityFile.exists());
     return entityFile;
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSWithMultipleNodeManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-applications-distributedshell/src/test/java/org/apache/hadoop/yarn/applications/distributedshell/TestDSWithMultipleNodeManager.java
@@ -28,13 +28,13 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TestName;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
@@ -116,24 +116,24 @@ public class TestDSWithMultipleNodeManager {
     return conf;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupUnitTests() throws Exception {
     TestDSTimelineV10.setupUnitTests();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownUnitTests() throws Exception {
     TestDSTimelineV10.tearDownUnitTests();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     distShellTest = new TestDSTimelineV10();
     distShellTest.setupInternal(NUM_NMS,
         getConfiguration(multiNodePlacementEnabled));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (dsClient != null) {
       dsClient.sendStopSignal();
@@ -211,7 +211,7 @@ public class TestDSWithMultipleNodeManager {
       dsClient =
           new Client(
               new Configuration(distShellTest.getYarnClusterConfiguration()));
-      Assert.assertTrue(dsClient.init(args));
+      Assertions.assertTrue(dsClient.init(args));
       LOG.info("Running DS Client");
       boolean result = dsClient.run();
       LOG.info("Client run completed. Result={}", result);
@@ -222,9 +222,9 @@ public class TestDSWithMultipleNodeManager {
       int[] maxRunningContainersOnNMs =
           containerMonitorRunner.getMaxRunningContainersReport();
       // Check no container allocated on NM[0]
-      Assert.assertEquals(0, maxRunningContainersOnNMs[0]);
+      Assertions.assertEquals(0, maxRunningContainersOnNMs[0]);
       // Check there are some containers allocated on NM[1]
-      Assert.assertTrue(maxRunningContainersOnNMs[1] > 0);
+      Assertions.assertTrue(maxRunningContainersOnNMs[1] > 0);
     } finally {
       if (containerMonitorRunner != null) {
         containerMonitorRunner.stopMonitoring();
@@ -253,7 +253,7 @@ public class TestDSWithMultipleNodeManager {
       dsClient =
           new Client(
               new Configuration(distShellTest.getYarnClusterConfiguration()));
-      Assert.assertTrue(dsClient.init(args));
+      Assertions.assertTrue(dsClient.init(args));
       LOG.info("Running DS Client");
       boolean result = dsClient.run();
       LOG.info("Client run completed. Result={}", result);
@@ -276,8 +276,8 @@ public class TestDSWithMultipleNodeManager {
 
       int[] maxRunningContainersOnNMs =
           containerMonitorRunner.getMaxRunningContainersReport();
-      Assert.assertEquals(expectedNMsCount[0], maxRunningContainersOnNMs[0]);
-      Assert.assertEquals(expectedNMsCount[1], maxRunningContainersOnNMs[1]);
+      Assertions.assertEquals(expectedNMsCount[0], maxRunningContainersOnNMs[0]);
+      Assertions.assertEquals(expectedNMsCount[1], maxRunningContainersOnNMs[1]);
     } finally {
       if (containerMonitorRunner != null) {
         containerMonitorRunner.stopMonitoring();
@@ -339,7 +339,7 @@ public class TestDSWithMultipleNodeManager {
           getNodeId();
       NodeId nodeB = distShellTest.getNodeManager(1).getNMContext().
           getNodeId();
-      Assert.assertEquals(2, (expectedNMCounts[0] + expectedNMCounts[1]));
+      Assertions.assertEquals(2, (expectedNMCounts[0] + expectedNMCounts[1]));
       if (expectedNMCounts[0] != expectedNMCounts[1]) {
         taskContainerNodeIdA = masterContainerNodeIdARef.get();
       } else {
@@ -351,7 +351,7 @@ public class TestDSWithMultipleNodeManager {
           new Client(
               new Configuration(distShellTest.getYarnClusterConfiguration()));
       clientB.init(argsB);
-      Assert.assertTrue(clientB.run());
+      Assertions.assertTrue(clientB.run());
       containerMonitorRunner.stopMonitoring();
       apps = distShellTest.getResourceManager().getRMContext().getRMApps();
       Iterator<RMApp> it = apps.values().iterator();
@@ -379,8 +379,8 @@ public class TestDSWithMultipleNodeManager {
       }
       int[] maxRunningContainersOnNMs =
           containerMonitorRunner.getMaxRunningContainersReport();
-      Assert.assertEquals(expectedNMCounts[0], maxRunningContainersOnNMs[0]);
-      Assert.assertEquals(expectedNMCounts[1], maxRunningContainersOnNMs[1]);
+      Assertions.assertEquals(expectedNMCounts[0], maxRunningContainersOnNMs[0]);
+      Assertions.assertEquals(expectedNMCounts[1], maxRunningContainersOnNMs[1]);
 
       try {
         yarnClient = YarnClient.createYarnClient();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestDefaultUpgradeComponentsFinder.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.api.records.Service;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link UpgradeComponentsFinder.DefaultUpgradeComponentsFinder}.
@@ -44,9 +44,9 @@ public class TestDefaultUpgradeComponentsFinder {
     targetDef.getComponents().forEach(x -> x.setArtifact(
         TestServiceManager.createTestArtifact("v1")));
 
-    assertEquals("all components need upgrade",
-        targetDef.getComponents(), finder.findTargetComponentSpecs(currentDef,
-            targetDef));
+    assertEquals(
+       targetDef.getComponents(), finder.findTargetComponentSpecs(currentDef,
+            targetDef), "all components need upgrade");
   }
 
   @Test
@@ -60,7 +60,7 @@ public class TestDefaultUpgradeComponentsFinder {
 
     try {
       finder.findTargetComponentSpecs(currentDef, targetDef);
-      Assert.fail("Expected error since component does not exist in service "
+      Assertions.fail("Expected error since component does not exist in service "
           + "definition");
     } catch (UnsupportedOperationException usoe) {
       assertEquals(
@@ -83,9 +83,9 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.add(targetDef.getComponents().get(0));
 
-    assertEquals("single components needs upgrade",
-        expected, finder.findTargetComponentSpecs(currentDef,
-            targetDef));
+    assertEquals(
+       expected, finder.findTargetComponentSpecs(currentDef,
+            targetDef), "single components needs upgrade");
   }
 
   @Test
@@ -117,7 +117,7 @@ public class TestDefaultUpgradeComponentsFinder {
     List<Component> expected = new ArrayList<>();
     expected.addAll(targetDef.getComponents());
 
-    assertEquals("all components needs upgrade",
-        expected, finder.findTargetComponentSpecs(currentDef, targetDef));
+    assertEquals(
+       expected, finder.findTargetComponentSpecs(currentDef, targetDef), "all components needs upgrade");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/TestServiceManager.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.hadoop.yarn.service.exceptions.SliderException;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,15 +51,17 @@ public class TestServiceManager {
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
-  @Test (timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testUpgrade");
     initUpgrade(context, "v2", false, false, false);
-    Assert.assertEquals("service not upgraded", ServiceState.UPGRADING,
-        context.getServiceManager().getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         context.getServiceManager().getServiceSpec().getState(), "service not upgraded");
   }
 
-  @Test (timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testRestartNothingToUpgrade()
       throws Exception {
     ServiceContext context = createServiceContext(
@@ -73,11 +76,12 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not re-started", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service not re-started");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testAutoFinalizeNothingToUpgrade() throws Exception {
     ServiceContext context = createServiceContext(
         "testAutoFinalizeNothingToUpgrade");
@@ -89,11 +93,12 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service stable", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service stable");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testRestartWithPendingUpgrade()
       throws Exception {
     ServiceContext context = createServiceContext("testRestart");
@@ -103,17 +108,18 @@ public class TestServiceManager {
     context.scheduler.getDispatcher().getEventHandler().handle(
         new ServiceEvent(ServiceEventType.START));
     context.scheduler.getDispatcher().stop();
-    Assert.assertEquals("service should still be upgrading",
-        ServiceState.UPGRADING, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.UPGRADING, manager.getServiceSpec().getState(), "service should still be upgrading");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testFinalize() throws Exception {
     ServiceContext context = createServiceContext("testCheckState");
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     //make components stable by upgrading all instances
     upgradeAndReadyAllInstances(context);
@@ -124,13 +130,14 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not re-started", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service not re-started");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testAutoFinalize() throws Exception {
     ServiceContext context = createServiceContext("testCheckStateAutoFinalize");
     ServiceManager manager = context.getServiceManager();
@@ -144,8 +151,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(() ->
         context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service not stable",
-        ServiceState.STABLE, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
 
     validateUpgradeFinalization(manager.getName(), "v2");
   }
@@ -165,13 +172,14 @@ public class TestServiceManager {
     try {
       manager.processUpgradeRequest("v2", true, false);
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof UnsupportedOperationException);
+      Assertions.assertTrue(ex instanceof UnsupportedOperationException);
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testExpressUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testExpressUpgrade");
     ServiceManager manager = context.getServiceManager();
@@ -191,19 +199,20 @@ public class TestServiceManager {
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
 
-    Assert.assertEquals("service not stable",
-        ServiceState.STABLE, manager.getServiceSpec().getState());
+    Assertions.assertEquals(
+       ServiceState.STABLE, manager.getServiceSpec().getState(), "service not stable");
     validateUpgradeFinalization(manager.getName(), "v2");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testCancelUpgrade() throws Exception {
     ServiceContext context = createServiceContext("testCancelUpgrade");
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     List<String> comps = ServiceApiUtil.resolveCompsDependency(context.service);
     // wait till instances of first component are upgraded and ready
@@ -220,20 +229,21 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service upgrade not cancelled", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
 
-  @Test(timeout = TIMEOUT)
+  @Test
+  @Timeout(value = TIMEOUT)
   public void testCancelUpgradeAfterInitiate() throws Exception {
     ServiceContext context = createServiceContext("testCancelUpgrade");
     writeInitialDef(context.service);
     initUpgrade(context, "v2", true, false, false);
     ServiceManager manager = context.getServiceManager();
-    Assert.assertEquals("service not upgrading", ServiceState.UPGRADING,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.UPGRADING
+,         manager.getServiceSpec().getState(), "service not upgrading");
 
     // cancel upgrade
     context.scheduler.getDispatcher().getEventHandler().handle(
@@ -241,8 +251,8 @@ public class TestServiceManager {
     GenericTestUtils.waitFor(()->
             context.service.getState().equals(ServiceState.STABLE),
         CHECK_EVERY_MILLIS, TIMEOUT);
-    Assert.assertEquals("service upgrade not cancelled", ServiceState.STABLE,
-        manager.getServiceSpec().getState());
+    Assertions.assertEquals(ServiceState.STABLE
+,         manager.getServiceSpec().getState(), "service upgrade not cancelled");
 
     validateUpgradeFinalization(manager.getName(), "v1");
   }
@@ -250,14 +260,14 @@ public class TestServiceManager {
   private void validateUpgradeFinalization(String serviceName,
       String expectedVersion) throws IOException {
     Service savedSpec = ServiceApiUtil.loadService(rule.getFs(), serviceName);
-    Assert.assertEquals("service def not re-written", expectedVersion,
-        savedSpec.getVersion());
-    Assert.assertNotNull("app id not present", savedSpec.getId());
-    Assert.assertEquals("state not stable", ServiceState.STABLE,
-        savedSpec.getState());
+    Assertions.assertEquals(expectedVersion
+,         savedSpec.getVersion(), "service def not re-written");
+    Assertions.assertNotNull(savedSpec.getId(), "app id not present");
+    Assertions.assertEquals(ServiceState.STABLE
+,         savedSpec.getState(), "state not stable");
     savedSpec.getComponents().forEach(compSpec ->
-        Assert.assertEquals("comp not stable", ComponentState.STABLE,
-        compSpec.getState()));
+        Assertions.assertEquals(ComponentState.STABLE
+,         compSpec.getState(), "comp not stable"));
   }
 
   private void initUpgrade(ServiceContext context, String version,
@@ -426,6 +436,6 @@ public class TestServiceManager {
         upgradedDef);
   }
 
-  private static final int TIMEOUT = 10000;
+  private static final int TIMEOUT = 10;
   private static final int CHECK_EVERY_MILLIS = 100;
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestBuildExternalComponents.java
@@ -25,10 +25,10 @@ import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.conf.ExampleAppJson;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,9 +49,9 @@ public class TestBuildExternalComponents {
   // Check component names match with expected
   private static void checkComponentNames(List<Component> components,
       Set<String> expectedComponents) {
-    Assert.assertEquals(expectedComponents.size(), components.size());
+    Assertions.assertEquals(expectedComponents.size(), components.size());
     for (Component comp : components) {
-      Assert.assertTrue(expectedComponents.contains(comp.getName()));
+      Assertions.assertTrue(expectedComponents.contains(comp.getName()));
     }
   }
 
@@ -70,7 +70,7 @@ public class TestBuildExternalComponents {
     checkComponentNames(components, names);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     basedir = new File("target", "apps");
     if (basedir.exists()) {
@@ -81,7 +81,7 @@ public class TestBuildExternalComponents {
     conf.set(YARN_SERVICE_BASE_PATH, basedir.getAbsolutePath());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceCLI.java
@@ -34,11 +34,12 @@ import org.apache.hadoop.yarn.service.conf.ExampleAppJson;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class TestServiceCLI {
         "-D", basedirProp, "-save", serviceName,
         ExampleAppJson.resourceName(appDef),
         "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private void buildApp(String serviceName, String appDef,
@@ -108,7 +109,7 @@ public class TestServiceCLI {
         "-appTypes", DUMMY_APP_TYPE,
         "-updateLifetime", lifetime,
         "-changeQueue", queue};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
   }
 
   private static Path getDependencyTarGz(File dir) {
@@ -117,7 +118,7 @@ public class TestServiceCLI {
         .DEPENDENCY_TAR_GZ_FILE_EXT).getAbsolutePath());
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Throwable {
     basedir = new File("target", "apps");
     basedirProp = YARN_SERVICE_BASE_PATH + "=" + basedir.getAbsolutePath();
@@ -145,7 +146,7 @@ public class TestServiceCLI {
     createCLI();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);
@@ -153,7 +154,8 @@ public class TestServiceCLI {
     cli.stop();
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testFlexComponents() throws Throwable {
     // currently can only test building apps, since that is the only
     // operation that doesn't require an RM
@@ -176,7 +178,8 @@ public class TestServiceCLI {
     assertThat(result).isEqualTo(0);
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testInitiateAutoFinalizeServiceUpgrade() throws Exception {
     String[] args =  {"app", "-upgrade", "app-1",
         "-initiate", ExampleAppJson.resourceName(ExampleAppJson.APP_JSON),
@@ -233,40 +236,43 @@ public class TestServiceCLI {
     assertThat(result).isEqualTo(0);
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunch() throws Exception {
     fs.getFileSystem().create(new Path(basedir.getAbsolutePath(), "test.jar"))
         .close();
 
     Path defaultPath = new Path(dependencyTarGz.toString());
-    Assert.assertFalse("Dependency tarball should not exist before the test",
-        fs.isFile(defaultPath));
+    Assertions.assertFalse(
+       fs.isFile(defaultPath), "Dependency tarball should not exist before the test");
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args));
-    Assert.assertTrue("Dependency tarball did not exist after the test",
-        fs.isFile(defaultPath));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args));
+    Assertions.assertTrue(
+       fs.isFile(defaultPath), "Dependency tarball did not exist after the test");
 
     File secondBaseDir = new File(dependencyTarGzBaseDir, "2");
     Path secondTarGz = getDependencyTarGz(secondBaseDir);
-    Assert.assertFalse("Dependency tarball should not exist before the test",
-        fs.isFile(secondTarGz));
+    Assertions.assertFalse(
+       fs.isFile(secondTarGz), "Dependency tarball should not exist before the test");
     String[] args2 = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dfsAdminAclProp, "-D", dependencyTarGzProp, "-enableFastLaunch",
         secondBaseDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_SUCCESS, runCLI(args2));
-    Assert.assertTrue("Dependency tarball did not exist after the test",
-        fs.isFile(secondTarGz));
+    Assertions.assertEquals(EXIT_SUCCESS, runCLI(args2));
+    Assertions.assertTrue(
+       fs.isFile(secondTarGz), "Dependency tarball did not exist after the test");
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunchUserPermissions() throws Exception {
     String[] args = {"app", "-D", yarnAdminNoneAclProp, "-D",
         dependencyTarGzProp, "-enableFastLaunch", "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
   }
 
-  @Test (timeout = 180000)
+  @Test
+  @Timeout(value = 180)
   public void testEnableFastLaunchFilePermissions() throws Exception {
     File badDir = new File(dependencyTarGzBaseDir, "bad");
     badDir.mkdir();
@@ -275,7 +281,7 @@ public class TestServiceCLI {
 
     String[] args = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args));
 
     badDir = new File(badDir, "child");
     badDir.mkdir();
@@ -284,7 +290,7 @@ public class TestServiceCLI {
 
     String[] args2 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args2));
 
     badDir = new File(dependencyTarGzBaseDir, "badx");
     badDir.mkdir();
@@ -293,24 +299,24 @@ public class TestServiceCLI {
 
     String[] args3 = {"app", "-D", dependencyTarGzProp, "-enableFastLaunch",
         badDir.getAbsolutePath(), "-appTypes", DUMMY_APP_TYPE};
-    Assert.assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
+    Assertions.assertEquals(EXIT_UNAUTHORIZED, runCLI(args3));
   }
 
   private void checkApp(String serviceName, String compName, long count, Long
       lifetime, String queue) throws IOException {
     Service service = ServiceApiUtil.loadService(fs, serviceName);
-    Assert.assertEquals(serviceName, service.getName());
-    Assert.assertEquals(lifetime, service.getLifetime());
-    Assert.assertEquals(queue, service.getQueue());
+    Assertions.assertEquals(serviceName, service.getName());
+    Assertions.assertEquals(lifetime, service.getLifetime());
+    Assertions.assertEquals(queue, service.getQueue());
     List<Component> components = service.getComponents();
     for (Component component : components) {
       if (component.getName().equals(compName)) {
-        Assert.assertEquals(count, component.getNumberOfContainers()
+        Assertions.assertEquals(count, component.getNumberOfContainers()
             .longValue());
         return;
       }
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   private static final String DUMMY_APP_TYPE = "dummy";

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/client/TestServiceClient.java
@@ -49,9 +49,9 @@ import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
 import org.apache.hadoop.yarn.service.exceptions.ErrorStrings;
 import org.apache.hadoop.yarn.service.utils.FilterUtils;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,12 +89,12 @@ public class TestServiceClient {
     client.getConfig().set("yarn.service.classpath", "{{VAR_1}},{{VAR_2}}");
     String newPath = client.addAMEnv().get("CLASSPATH");
 
-    Assert.assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
+    Assertions.assertEquals(originalPath + "<CPS>{{VAR_1}}<CPS>{{VAR_2}}", newPath);
     //restoring the original value for service classpath
     client.getConfig().set("yarn.service.classpath", oldParam);
 
     newPath = client.addAMEnv().get("CLASSPATH");
-    Assert.assertEquals(originalPath, newPath);
+    Assertions.assertEquals(originalPath, newPath);
 
     client.stop();
   }
@@ -109,11 +109,11 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assert.assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
+      Assertions.assertEquals(ErrorStrings.SERVICE_UPGRADE_DISABLED,
           ex.getMessage());
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -127,8 +127,8 @@ public class TestServiceClient {
 
     Service fromFs = ServiceApiUtil.loadServiceUpgrade(rule.getFs(),
         service.getName(), service.getVersion());
-    Assert.assertEquals(service.getName(), fromFs.getName());
-    Assert.assertEquals(service.getVersion(), fromFs.getVersion());
+    Assertions.assertEquals(service.getName(), fromFs.getName());
+    Assertions.assertEquals(service.getVersion(), fromFs.getVersion());
     client.stop();
   }
 
@@ -149,7 +149,7 @@ public class TestServiceClient {
     client.actionUpgrade(service, comp.getContainers());
     CompInstancesUpgradeResponseProto response = client.getLastProxyResponse(
         CompInstancesUpgradeResponseProto.class);
-    Assert.assertNotNull("upgrade did not complete", response);
+    Assertions.assertNotNull(response, "upgrade did not complete");
     client.stop();
   }
 
@@ -169,11 +169,11 @@ public class TestServiceClient {
 
     ComponentContainers[] compContainers = client.getContainers(
         service.getName(), Lists.newArrayList("compa"), "v1", null);
-    Assert.assertEquals("num comp", 1, compContainers.length);
-    Assert.assertEquals("comp name", "compa",
+    Assertions.assertEquals(1, compContainers.length, "num comp");
+    Assertions.assertEquals("comp name", "compa",
         compContainers[0].getComponentName());
-    Assert.assertEquals("num containers", 2,
-        compContainers[0].getContainers().size());
+    Assertions.assertEquals(2
+,         compContainers[0].getContainers().size(), "num containers");
     client.stop();
   }
 
@@ -191,13 +191,13 @@ public class TestServiceClient {
     try {
       client.initiateUpgrade(service);
     } catch (YarnException ex) {
-      Assert.assertEquals("All the components of the service " +
+      Assertions.assertEquals("All the components of the service " +
               service.getName() + " have " + Component.RestartPolicyEnum.NEVER
               + " restart policy, so it cannot be upgraded.",
           ex.getMessage());
       return;
     }
-    Assert.fail();
+    Assertions.fail();
   }
 
   private Service createService() throws IOException,

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponent.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEvent;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceEventType;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
@@ -64,8 +64,8 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.UPGRADE);
     comp.handle(upgradeEvent);
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
   }
 
   @Test
@@ -83,17 +83,17 @@ public class TestComponent {
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
 
     // second instance finished upgrading
     comp.getUpgradeStatus().decContainersThatNeedUpgrade();
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("component did not upgrade successfully", "val1",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("component did not upgrade successfully", "val1",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -124,8 +124,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
   }
 
   @Test
@@ -137,10 +137,10 @@ public class TestComponent {
     ComponentEvent upgradeEvent = new ComponentEvent(comp.getName(),
         ComponentEventType.CANCEL_UPGRADE);
     comp.handle(upgradeEvent);
-    Assert.assertEquals("component not in need upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in need upgrade state");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -190,16 +190,16 @@ public class TestComponent {
     comp.handle(stopEvent);
     instance1.handle(new ComponentInstanceEvent(
         instance1.getContainer().getId(), STOP));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
-    Assert.assertEquals(
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
@@ -214,17 +214,17 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in flexing state",
-        ComponentState.FLEXING, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
     // new container get allocated
     context.assignNewContainer(context.attemptId, 10, comp);
 
     comp.handle(new ComponentEvent(comp.getName(),
             ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -249,9 +249,9 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -272,8 +272,8 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in flexing state",
-        ComponentState.FLEXING, comp.getComponentSpec().getState());
+    Assertions.assertEquals(
+       ComponentState.FLEXING, comp.getComponentSpec().getState(), "component not in flexing state");
 
     for (ComponentInstance instance : comp.getAllComponentInstances()) {
       // new container get allocated
@@ -283,9 +283,9 @@ public class TestComponent {
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in stable state",
-        ComponentState.STABLE, comp.getComponentSpec().getState());
-    Assert.assertEquals("cancel upgrade failed", "val0",
+    Assertions.assertEquals(
+       ComponentState.STABLE, comp.getComponentSpec().getState(), "component not in stable state");
+    Assertions.assertEquals("cancel upgrade failed", "val0",
         comp.getComponentSpec().getConfiguration().getEnv("key1"));
   }
 
@@ -327,16 +327,16 @@ public class TestComponent {
         instance1.getContainer().getId(), STOP));
 
     // component should be in cancel upgrade
-    Assert.assertEquals(
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
 
     comp.handle(new ComponentEvent(comp.getName(),
         ComponentEventType.CHECK_STABLE));
 
-    Assert.assertEquals("component not in needs upgrade state",
-        ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState());
-    Assert.assertEquals(
+    Assertions.assertEquals(
+       ComponentState.NEEDS_UPGRADE, comp.getComponentSpec().getState(), "component not in needs upgrade state");
+    Assertions.assertEquals(
         org.apache.hadoop.yarn.service.component.ComponentState
             .CANCEL_UPGRADING, comp.getState());
   }
@@ -362,11 +362,11 @@ public class TestComponent {
       ComponentInstance componentInstance = instanceIter.next();
       Container instanceContainer = componentInstance.getContainer();
 
-      Assert.assertEquals(0, comp.getNumSucceededInstances());
-      Assert.assertEquals(0, comp.getNumFailedInstances());
-      Assert.assertEquals(2, comp.getNumRunningInstances());
-      Assert.assertEquals(2, comp.getNumReadyInstances());
-      Assert.assertEquals(0, comp.getPendingInstances().size());
+      Assertions.assertEquals(0, comp.getNumSucceededInstances());
+      Assertions.assertEquals(0, comp.getNumFailedInstances());
+      Assertions.assertEquals(2, comp.getNumRunningInstances());
+      Assertions.assertEquals(2, comp.getNumReadyInstances());
+      Assertions.assertEquals(0, comp.getPendingInstances().size());
 
       //stop 1 container
       ContainerStatus containerStatus = ContainerStatus.newInstance(
@@ -380,15 +380,15 @@ public class TestComponent {
           new ComponentInstanceEvent(componentInstance.getContainer().getId(),
               ComponentInstanceEventType.STOP).setStatus(containerStatus));
 
-      Assert.assertEquals(1, comp.getNumSucceededInstances());
-      Assert.assertEquals(0, comp.getNumFailedInstances());
-      Assert.assertEquals(1, comp.getNumRunningInstances());
-      Assert.assertEquals(1, comp.getNumReadyInstances());
-      Assert.assertEquals(0, comp.getPendingInstances().size());
+      Assertions.assertEquals(1, comp.getNumSucceededInstances());
+      Assertions.assertEquals(0, comp.getNumFailedInstances());
+      Assertions.assertEquals(1, comp.getNumRunningInstances());
+      Assertions.assertEquals(1, comp.getNumReadyInstances());
+      Assertions.assertEquals(0, comp.getPendingInstances().size());
 
       org.apache.hadoop.yarn.service.component.ComponentState componentState =
           Component.checkIfStable(comp);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           org.apache.hadoop.yarn.service.component.ComponentState.STABLE,
           componentState);
     }
@@ -431,14 +431,14 @@ public class TestComponent {
 
       ComponentState componentState =
           comp.getComponentSpec().getState();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ComponentState.SUCCEEDED,
           componentState);
     }
 
     ServiceState serviceState =
         testService.getState();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }
@@ -484,7 +484,7 @@ public class TestComponent {
         }
         ComponentState componentState =
             comp.getComponentSpec().getState();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ComponentState.SUCCEEDED,
             componentState);
       }
@@ -492,7 +492,7 @@ public class TestComponent {
 
     ServiceState serviceState =
         testService.getState();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ServiceState.SUCCEEDED,
         serviceState);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentDecommissionInstances.java
@@ -27,11 +27,11 @@ import org.apache.hadoop.yarn.service.api.records.Container;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.client.ServiceClient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,13 +58,13 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     File tmpYarnDir = new File("target", "tmp");
     FileUtils.deleteQuietly(tmpYarnDir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     shutdown();
   }
@@ -129,19 +129,19 @@ public class TestComponentDecommissionInstances extends ServiceTestUtils {
       throws IOException, YarnException {
     Service service = client.getStatus(APP_NAME);
     Component component = service.getComponent(COMPA);
-    Assert.assertEquals("Service state should be STABLE", ServiceState.STABLE,
-        service.getState());
-    Assert.assertEquals(instances.length + " containers are expected to be " +
-        "running", instances.length, component.getContainers().size());
+    Assertions.assertEquals(ServiceState.STABLE
+,         service.getState(), "Service state should be STABLE");
+    Assertions.assertEquals(instances.length, component.getContainers().size(), instances.length + " containers are expected to be " +
+        "running");
     Set<String> existingInstances = new HashSet<>();
     for (Container cont : component.getContainers()) {
       existingInstances.add(cont.getComponentInstanceName());
     }
-    Assert.assertEquals(instances.length + " instances are expected to be " +
-        "running", instances.length, existingInstances.size());
+    Assertions.assertEquals(instances.length, existingInstances.size(), instances.length + " instances are expected to be " +
+        "running");
     for (String instance : instances) {
-      Assert.assertTrue("Expected instance did not exist " + instance,
-          existingInstances.contains(instance));
+      Assertions.assertTrue(
+         existingInstances.contains(instance), "Expected instance did not exist " + instance);
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentRestartPolicy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/TestComponentRestartPolicy.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.yarn.service.component;
 
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/component/instance/TestComponentInstance.java
@@ -42,9 +42,9 @@ import org.apache.hadoop.yarn.service.component.ComponentEvent;
 import org.apache.hadoop.yarn.service.component.ComponentEventType;
 import org.apache.hadoop.yarn.service.component.TestComponent;
 import org.apache.hadoop.yarn.service.utils.ServiceUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.file.Files;
@@ -90,8 +90,8 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     Container containerSpec = component.getComponentSpec().getContainer(
         instance.getContainer().getId().toString());
-    Assert.assertEquals("instance not upgrading", ContainerState.UPGRADING,
-        containerSpec.getState());
+    Assertions.assertEquals(ContainerState.UPGRADING
+,         containerSpec.getState(), "instance not upgrading");
   }
 
   @Test
@@ -110,15 +110,15 @@ public class TestComponentInstance {
     instance.handle(instanceEvent);
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assert.assertEquals("instance not running",
-        ContainerState.RUNNING_BUT_UNREADY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.RUNNING_BUT_UNREADY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not running");
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.BECOME_READY));
-    Assert.assertEquals("instance not ready", ContainerState.READY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.READY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not ready");
   }
 
 
@@ -145,9 +145,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assert.assertEquals("instance did not fail", ContainerState.FAILED_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -168,10 +168,10 @@ public class TestComponentInstance {
     // NM finished updgrae
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.START));
-    Assert.assertEquals("instance not running",
-        ContainerState.RUNNING_BUT_UNREADY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.RUNNING_BUT_UNREADY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not running");
 
     ContainerStatus containerStatus = mock(ContainerStatus.class);
     when(containerStatus.getExitStatus()).thenReturn(
@@ -181,9 +181,9 @@ public class TestComponentInstance {
         .setStatus(containerStatus);
     // this is the call back from NM for the upgrade
     instance.handle(stopEvent);
-    Assert.assertEquals("instance did not fail", ContainerState.FAILED_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.FAILED_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance did not fail");
   }
 
   @Test
@@ -202,9 +202,9 @@ public class TestComponentInstance {
         ComponentInstanceEventType.CANCEL_UPGRADE);
     instance.handle(cancelEvent);
 
-    Assert.assertEquals("instance not ready", ContainerState.READY,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.READY
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not ready");
   }
 
   @Test
@@ -225,8 +225,8 @@ public class TestComponentInstance {
 
     instance.handle(new ComponentInstanceEvent(instance.getContainer().getId(),
         ComponentInstanceEventType.STOP));
-    Assert.assertEquals("instance not init", ComponentInstanceState.INIT,
-        instance.getState());
+    Assertions.assertEquals(ComponentInstanceState.INIT
+,         instance.getState(), "instance not init");
   }
 
   @Test
@@ -244,10 +244,10 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assert.assertEquals("instance should start upgrading",
-        ContainerState.NEEDS_UPGRADE,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.NEEDS_UPGRADE
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance should start upgrading");
   }
 
   @Test
@@ -296,30 +296,30 @@ public class TestComponentInstance {
         LocalizationState.PENDING);
 
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assert.assertTrue("retriever should still be active",
-        instance.isLclRetrieverActive());
+    Assertions.assertTrue(
+       instance.isLclRetrieverActive(), "retriever should still be active");
 
     Container container = instance.getContainerSpec();
-    Assert.assertTrue(container.getLocalizationStatuses() != null);
-    Assert.assertEquals("dest file",
-        container.getLocalizationStatuses().get(0).getDestFile(),
-        status.getResourceKey());
-    Assert.assertEquals("state",
-        container.getLocalizationStatuses().get(0).getState(),
-        status.getLocalizationState());
+    Assertions.assertTrue(container.getLocalizationStatuses() != null);
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getDestFile()
+,         status.getResourceKey(), "dest file");
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getState()
+,         status.getLocalizationState(), "state");
 
     status = LocalizationStatus.newInstance("file1",
         LocalizationState.COMPLETED);
     instance.updateLocalizationStatuses(Lists.newArrayList(status));
-    Assert.assertTrue("retriever should not be active",
-        !instance.isLclRetrieverActive());
-    Assert.assertTrue(container.getLocalizationStatuses() != null);
-    Assert.assertEquals("dest file",
-        container.getLocalizationStatuses().get(0).getDestFile(),
-        status.getResourceKey());
-    Assert.assertEquals("state",
-        container.getLocalizationStatuses().get(0).getState(),
-        status.getLocalizationState());
+    Assertions.assertTrue(
+       !instance.isLclRetrieverActive(), "retriever should not be active");
+    Assertions.assertTrue(container.getLocalizationStatuses() != null);
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getDestFile()
+,         status.getResourceKey(), "dest file");
+    Assertions.assertEquals(
+       container.getLocalizationStatuses().get(0).getState()
+,         status.getLocalizationState(), "state");
   }
 
   private void validateCancelWhileUpgrading(boolean upgradeSuccessful,
@@ -337,10 +337,10 @@ public class TestComponentInstance {
         instance.getContainer().getId(), ComponentInstanceEventType.UPGRADE);
     instance.handle(upgradeEvent);
 
-    Assert.assertEquals("instance should be upgrading",
-        ContainerState.UPGRADING,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(
+       ContainerState.UPGRADING
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance should be upgrading");
 
     cancelCompUpgrade(component);
     ComponentInstanceEvent cancelEvent = new ComponentInstanceEvent(
@@ -361,9 +361,9 @@ public class TestComponentInstance {
           ComponentInstanceEventType.STOP));
     }
 
-    Assert.assertEquals("instance not upgrading", ContainerState.UPGRADING,
-        component.getComponentSpec().getContainer(instance.getContainer()
-            .getId().toString()).getState());
+    Assertions.assertEquals(ContainerState.UPGRADING
+,         component.getComponentSpec().getContainer(instance.getContainer()
+            .getId().toString()).getState(), "instance not upgrading");
 
     // response for cancel received
     if (cancelUpgradeSuccessful) {
@@ -377,12 +377,12 @@ public class TestComponentInstance {
           instance.getContainer().getId(), ComponentInstanceEventType.STOP));
     }
     if (cancelUpgradeSuccessful) {
-      Assert.assertEquals("instance not ready", ContainerState.READY,
-          component.getComponentSpec().getContainer(instance.getContainer()
-              .getId().toString()).getState());
+      Assertions.assertEquals(ContainerState.READY
+,           component.getComponentSpec().getContainer(instance.getContainer()
+              .getId().toString()).getState(), "instance not ready");
     } else {
-      Assert.assertEquals("instance not init", ComponentInstanceState.INIT,
-          instance.getState());
+      Assertions.assertEquals(ComponentInstanceState.INIT
+,           instance.getState(), "instance not init");
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestAppJsonResolve.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +41,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.yarn.service.conf.ExampleAppJson.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test global configuration resolution.
  */
-public class TestAppJsonResolve extends Assert {
+public class TestAppJsonResolve  {
   protected static final Logger LOG =
       LoggerFactory.getLogger(TestAppJsonResolve.class);
 
@@ -199,18 +200,18 @@ public class TestAppJsonResolve extends Assert {
 
     // Validate worker's resources
     Resource workerResource = orig.getComponent("worker").getResource();
-    Assert.assertEquals(1, workerResource.getCpus().intValue());
-    Assert.assertEquals(1024, workerResource.calcMemoryMB());
-    Assert.assertNotNull(workerResource.getAdditional());
-    Assert.assertEquals(2, workerResource.getAdditional().size());
-    Assert.assertEquals(3333, workerResource.getAdditional().get(
+    Assertions.assertEquals(1, workerResource.getCpus().intValue());
+    Assertions.assertEquals(1024, workerResource.calcMemoryMB());
+    Assertions.assertNotNull(workerResource.getAdditional());
+    Assertions.assertEquals(2, workerResource.getAdditional().size());
+    Assertions.assertEquals(3333, workerResource.getAdditional().get(
         "resource-1").getValue().longValue());
-    Assert.assertEquals("Gi", workerResource.getAdditional().get(
+    Assertions.assertEquals("Gi", workerResource.getAdditional().get(
         "resource-1").getUnit());
 
-    Assert.assertEquals(5, workerResource.getAdditional().get(
+    Assertions.assertEquals(5, workerResource.getAdditional().get(
         "yarn.io/gpu").getValue().longValue());
-    Assert.assertEquals("", workerResource.getAdditional().get(
+    Assertions.assertEquals("", workerResource.getAdditional().get(
         "yarn.io/gpu").getUnit());
 
     other = orig.getComponent("other").getConfiguration();
@@ -221,16 +222,16 @@ public class TestAppJsonResolve extends Assert {
   public void testSetResourceAttributes() throws IOException {
     Service orig = ExampleAppJson.loadResource(EXTERNAL_JSON_3);
     Component component = orig.getComponent("volume-service");
-    Assert.assertNotNull(component);
+    Assertions.assertNotNull(component);
     Map<String, ResourceInformation> adResource = component
         .getResource().getAdditional();
-    Assert.assertNotNull(adResource);
-    Assert.assertEquals(1, adResource.size());
+    Assertions.assertNotNull(adResource);
+    Assertions.assertEquals(1, adResource.size());
     Map.Entry<String, ResourceInformation> volume = adResource
         .entrySet().iterator().next();
-    Assert.assertEquals("yarn.io/csi-volume", volume.getKey());
-    Assert.assertEquals(100L, volume.getValue().getValue().longValue());
-    Assert.assertEquals(2, volume.getValue().getAttributes().size());
-    Assert.assertEquals(1, volume.getValue().getTags().size());
+    Assertions.assertEquals("yarn.io/csi-volume", volume.getKey());
+    Assertions.assertEquals(100L, volume.getValue().getValue().longValue());
+    Assertions.assertEquals(2, volume.getValue().getAttributes().size());
+    Assertions.assertEquals(1, volume.getValue().getTags().size());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestLoadExampleAppJson.java
@@ -23,28 +23,22 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.apache.hadoop.yarn.service.ServiceTestUtils.JSON_SER_DESER;
 
-/**
- * Test loading example resources.
- */
-@RunWith(value = Parameterized.class)
-public class TestLoadExampleAppJson extends Assert {
+
+public class TestLoadExampleAppJson {
   private String resource;
 
   public TestLoadExampleAppJson(String resource) {
     this.resource = resource;
   }
 
-  @Parameterized.Parameters
   public static Collection<String[]> filenames() {
     String[][] stringArray = new String[ExampleAppJson
         .ALL_EXAMPLE_RESOURCES.size()][1];
@@ -55,7 +49,8 @@ public class TestLoadExampleAppJson extends Assert {
     return Arrays.asList(stringArray);
   }
 
-  @Test
+  @MethodSource("filenames")
+  @ParameterizedTest
   public void testLoadResource() throws Throwable {
     try {
       Service service = JSON_SER_DESER.fromResource(resource);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/conf/TestValidateServiceNames.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.yarn.service.conf;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.service.utils.ServiceApiUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +38,7 @@ public class TestValidateServiceNames {
   void assertInvalidName(String name) {
     try {
       ServiceApiUtil.validateNameFormat(name, new Configuration());
-      Assert.fail();
+      Assertions.fail();
     } catch (IllegalArgumentException e) {
       //
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/containerlaunch/TestAbstractLauncher.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.yarn.service.component.OnFailureRestartPolicy;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.provider.defaultImpl
     .DefaultProviderService;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -53,7 +53,7 @@ public class TestAbstractLauncher {
 
   private AbstractLauncher launcher;
 
-  @Before
+  @BeforeEach
   public void setup() {
     launcher = new AbstractLauncher(mock(ServiceContext.class));
   }
@@ -68,7 +68,7 @@ public class TestAbstractLauncher {
     String dockerContainerMounts = launcher.containerLaunchContext
         .getEnvironment().get(AbstractLauncher.ENV_DOCKER_CONTAINER_MOUNTS);
 
-    Assert.assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
+    Assertions.assertEquals("s1:t1:ro,s2:t2:ro", dockerContainerMounts);
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/TestServiceMonitor.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.Component;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConf;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
   YarnConfiguration conf = new YarnConfiguration();
   TestingCluster zkCluster;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     basedir = new File("target", "apps");
     if (basedir.exists()) {
@@ -62,7 +62,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
     System.out.println("ZK cluster: " +  zkCluster.getConnectString());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (basedir != null) {
       FileUtils.deleteDirectory(basedir);
@@ -100,9 +100,9 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.start();
 
     // compa ready
-    Assert.assertTrue(am.getComponent("compa").areDependenciesReady());
+    Assertions.assertTrue(am.getComponent("compa").areDependenciesReady());
     //compb not ready
-    Assert.assertFalse(am.getComponent("compb").areDependenciesReady());
+    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
 
     // feed 1 container to compa,
     am.feedContainerToComp(exampleApp, 1, "compa");
@@ -120,7 +120,7 @@ public class TestServiceMonitor extends ServiceTestUtils {
     am.waitForNumDesiredContainers("compa", 2);
 
     // compb dependencies not satisfied again.
-    Assert.assertFalse(am.getComponent("compb").areDependenciesReady());
+    Assertions.assertFalse(am.getComponent("compb").areDependenciesReady());
     am.stop();
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/monitor/probe/TestDefaultProbe.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.service.monitor.probe;
 import org.apache.hadoop.yarn.api.records.ContainerStatus;
 import org.apache.hadoop.yarn.service.api.records.ReadinessCheck;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.invocation.InvocationOnMock;
@@ -32,8 +32,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,35 +89,35 @@ public class TestDefaultProbe {
       componentInstance, boolean expectDNSCheckFailure) {
     // on the first ping, null container status results in failure
     ProbeStatus probeStatus = probe.ping(componentInstance);
-    assertFalse("Expected failure for " + probeStatus.toString(),
-        probeStatus.isSuccess());
-    assertTrue("Expected IP failure for " + probeStatus.toString(),
-        probeStatus.toString().contains(
-        componentInstance.getCompInstanceName() + ": IP is not available yet"));
+    assertFalse(
+       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+    assertTrue(
+       probeStatus.toString().contains(
+        componentInstance.getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
 
     // on the second ping, container status is retrieved but there are no
     // IPs, resulting in failure
     probeStatus = probe.ping(componentInstance);
-    assertFalse("Expected failure for " + probeStatus.toString(),
-        probeStatus.isSuccess());
-    assertTrue("Expected IP failure for " + probeStatus.toString(),
-        probeStatus.toString().contains(componentInstance
-            .getCompInstanceName() + ": IP is not available yet"));
+    assertFalse(
+       probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+    assertTrue(
+       probeStatus.toString().contains(componentInstance
+            .getCompInstanceName() + ": IP is not available yet"), "Expected IP failure for " + probeStatus.toString());
 
     // on the third ping, IPs are retrieved and success depends on whether or
     // not a DNS lookup can be performed for the component instance hostname
     probeStatus = probe.ping(componentInstance);
     if (expectDNSCheckFailure) {
-      assertFalse("Expected failure for " + probeStatus.toString(),
-          probeStatus.isSuccess());
-      assertTrue("Expected DNS failure for " + probeStatus.toString(),
-          probeStatus.toString().contains(componentInstance
+      assertFalse(
+         probeStatus.isSuccess(), "Expected failure for " + probeStatus.toString());
+      assertTrue(
+         probeStatus.toString().contains(componentInstance
               .getCompInstanceName() + ": DNS checking is enabled, but lookup" +
               " for " + componentInstance.getHostname() + " is not available " +
-              "yet"));
+              "yet"), "Expected DNS failure for " + probeStatus.toString());
     } else {
-      assertTrue("Expected success for " + probeStatus.toString(),
-          probeStatus.isSuccess());
+      assertTrue(
+         probeStatus.isSuccess(), "Expected success for " + probeStatus.toString());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestAbstractProviderService.java
@@ -36,11 +36,11 @@ import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.provider.docker.DockerProviderService;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
@@ -62,7 +62,7 @@ public class TestAbstractProviderService {
   public ServiceTestUtils.ServiceFSWatcher rule =
       new ServiceTestUtils.ServiceFSWatcher();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     testService = TestServiceManager.createBaseDef("testService");
     serviceContext = new MockRunningServiceContext(rule, testService);
@@ -70,7 +70,7 @@ public class TestAbstractProviderService {
     rule.getFs().setAppDir(new Path("target/testAbstractProviderService"));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     FileUtils.deleteQuietly(
         new File(rule.getFs().getAppDir().toUri().getPath()));
@@ -91,8 +91,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assert.assertEquals("commands", Lists.newArrayList(clc.getLaunchCommand()),
-        launcher.getCommands());
+    Assertions.assertEquals(Lists.newArrayList(clc.getLaunchCommand())
+,         launcher.getCommands(), "commands");
   }
 
   @Test
@@ -110,8 +110,8 @@ public class TestAbstractProviderService {
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc,
         null);
 
-    Assert.assertEquals("commands don't match.",
-        Lists.newArrayList("ls,-l, space"), launcher.getCommands());
+    Assertions.assertEquals(
+       Lists.newArrayList("ls,-l, space"), launcher.getCommands(), "commands don't match.");
   }
 
   @Test
@@ -132,8 +132,8 @@ public class TestAbstractProviderService {
     providerService.buildContainerLaunchContext(launcher, testService, instance,
         rule.getFs(), serviceContext.scheduler.getConfig(), container, clc);
 
-    Assert.assertEquals("artifact", clc.getArtifact().getId(),
-        launcher.getDockerImage());
+    Assertions.assertEquals(clc.getArtifact().getId()
+,         launcher.getDockerImage(), "artifact");
   }
 
   private static ContainerLaunchService.ComponentLaunchContext

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/provider/TestProviderUtils.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.yarn.service.api.records.Configuration;
 import org.apache.hadoop.yarn.service.containerlaunch.AbstractLauncher;
 import org.apache.hadoop.yarn.service.containerlaunch.ContainerLaunchService;
 import org.apache.hadoop.yarn.service.utils.SliderFileSystem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -169,8 +169,8 @@ public class TestProviderUtils {
     Mockito.verify(launcher).addLocalResource(
         Mockito.eq("sourceFile4"), any(LocalResource.class));
 
-    Assert.assertEquals(3, resolved.getResolvedRsrcPaths().size());
-    Assert.assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
+    Assertions.assertEquals(3, resolved.getResolvedRsrcPaths().size());
+    Assertions.assertEquals(resolved.getResolvedRsrcPaths().get("destFile1"),
         "destFile1");
   }
 
@@ -179,7 +179,7 @@ public class TestProviderUtils {
     String command = "ls  -l \" space\"";
     String expected = "ls,-l, space";
     String actual = ProviderUtils.replaceSpacesWithDelimiter(command, ",");
-    Assert.assertEquals("replaceSpaceWithDelimiter produces unexpected result.",
-        expected, actual);
+    Assertions.assertEquals(
+       expected, actual, "replaceSpaceWithDelimiter produces unexpected result.");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestAbstractClientProvider.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.api.records.Artifact;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.provider.AbstractClientProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -69,21 +69,21 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "null file type");
+      Assertions.fail(EXCEPTION_PREFIX + "null file type");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setType(ConfigFile.TypeEnum.TEMPLATE);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "empty src_file for type template");
+      Assertions.fail(EXCEPTION_PREFIX + "empty src_file for type template");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setSrcFile("srcfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "empty dest file");
+      Assertions.fail(EXCEPTION_PREFIX + "empty dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -91,7 +91,7 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile = new ConfigFile();
@@ -101,7 +101,7 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
@@ -109,13 +109,13 @@ public class TestAbstractClientProvider {
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     configFile.setDestFile("destfile");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "duplicate dest file");
+      Assertions.fail(EXCEPTION_PREFIX + "duplicate dest file");
     } catch (IllegalArgumentException e) {
     }
 
@@ -127,14 +127,14 @@ public class TestAbstractClientProvider {
     configFiles.add(configFile);
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
+      Assertions.fail(EXCEPTION_PREFIX + "dest file with multiple path elements");
     } catch (IllegalArgumentException e) {
     }
 
     configFile.setDestFile("/path/destfile3");
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "src file should be specified");
+      Assertions.fail(EXCEPTION_PREFIX + "src file should be specified");
     } catch (IllegalArgumentException e) {
     }
 
@@ -156,7 +156,7 @@ public class TestAbstractClientProvider {
 
     try {
       clientProvider.validateConfigFiles(configFiles, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + "src file is a directory");
+      Assertions.fail(EXCEPTION_PREFIX + "src file is a directory");
     } catch (IllegalArgumentException e) {
     }
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestDefaultClientProvider.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.yarn.service.api.records.ConfigFile;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
 import org.apache.hadoop.yarn.service.provider.defaultImpl.DefaultClientProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestDefaultClientProvider {
   private static final String EXCEPTION_PREFIX = "Should have thrown "
@@ -48,19 +48,19 @@ public class TestDefaultClientProvider {
 
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
-      Assert.fail(EXCEPTION_PREFIX + " dest_file must be relative");
+      Assertions.fail(EXCEPTION_PREFIX + " dest_file must be relative");
     } catch (IllegalArgumentException e) {
       String actualMsg = String.format(
           RestApiErrorMessages.ERROR_CONFIGFILE_DEST_FILE_FOR_COMP_NOT_ABSOLUTE,
           compName, "no", configFile.getDestFile());
-      Assert.assertEquals(actualMsg, e.getLocalizedMessage());
+      Assertions.assertEquals(actualMsg, e.getLocalizedMessage());
     }
 
     configFile.setDestFile("../a.txt");
     try {
       defaultClientProvider.validateConfigFile(configFile, compName, mockFs);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getLocalizedMessage());
     }
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestProviderFactory.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/providers/TestProviderFactory.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.yarn.service.provider.tarball.TarballClientProvider;
 import org.apache.hadoop.yarn.service.provider.tarball.TarballProviderFactory;
 import org.apache.hadoop.yarn.service.provider.tarball.TarballProviderService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test provider factories.

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/timelineservice/TestServiceTimelinePublisher.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/timelineservice/TestServiceTimelinePublisher.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.yarn.service.api.records.PlacementType;
 import org.apache.hadoop.yarn.service.api.records.Resource;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstance;
 import org.apache.hadoop.yarn.service.component.instance.ComponentInstanceId;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,7 +78,7 @@ public class TestServiceTimelinePublisher {
   private static String CONTAINER_BAREHOST =
       "localhost.com";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     config = new Configuration();
     config.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -90,7 +90,7 @@ public class TestServiceTimelinePublisher {
     serviceTimelinePublisher.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (serviceTimelinePublisher != null) {
       serviceTimelinePublisher.stop();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestCoreFileSystem.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.yarn.service.utils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.conf.YarnServiceConstants;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link CoreFileSystem}.
@@ -40,7 +40,7 @@ public class TestCoreFileSystem {
     String version = "v1";
     Path expectedPath = new Path(rule.getFs().buildClusterDirPath(serviceName),
         YarnServiceConstants.UPGRADE_DIR + "/" + version);
-    Assert.assertEquals("incorrect upgrade path", expectedPath,
-        rule.getFs().buildClusterUpgradeDirPath(serviceName, version));
+    Assertions.assertEquals(expectedPath
+,         rule.getFs().buildClusterUpgradeDirPath(serviceName, version), "incorrect upgrade path");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestFilterUtils.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.yarn.service.ServiceTestUtils;
 import org.apache.hadoop.yarn.service.TestServiceManager;
 import org.apache.hadoop.yarn.service.api.records.ComponentContainers;
 import org.apache.hadoop.yarn.service.api.records.ContainerState;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -45,9 +45,9 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assert.assertEquals("num comps", 2, compContainers.size());
+    Assertions.assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assert.assertEquals("num containers", 2, item.getContainers().size());
+      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
     });
   }
 
@@ -58,12 +58,12 @@ public class TestFilterUtils {
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(
         new MockRunningServiceContext(rule,
             TestServiceManager.createBaseDef("service")), req);
-    Assert.assertEquals("num comps", 1, compContainers.size());
-    Assert.assertEquals("comp name", "compa",
+    Assertions.assertEquals(1, compContainers.size(), "num comps");
+    Assertions.assertEquals("comp name", "compa",
         compContainers.get(0).getComponentName());
 
-    Assert.assertEquals("num containers", 2,
-        compContainers.get(0).getContainers().size());
+    Assertions.assertEquals(2
+,         compContainers.get(0).getContainers().size(), "num containers");
   }
 
   @Test
@@ -74,15 +74,15 @@ public class TestFilterUtils {
         GetCompInstancesRequestProto.newBuilder();
 
     reqBuilder.setVersion("v2");
-    Assert.assertEquals("num comps", 0,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).size());
+    Assertions.assertEquals(0
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
 
     reqBuilder.addAllComponentNames(Lists.newArrayList("compa"))
         .setVersion("v1").build();
 
-    Assert.assertEquals("num containers", 2,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
-            .getContainers().size());
+    Assertions.assertEquals(2
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).get(0)
+            .getContainers().size(), "num containers");
   }
 
   @Test
@@ -96,16 +96,16 @@ public class TestFilterUtils {
         ContainerState.READY.toString()));
     List<ComponentContainers> compContainers = FilterUtils.filterInstances(sc,
         reqBuilder.build());
-    Assert.assertEquals("num comps", 2, compContainers.size());
+    Assertions.assertEquals(2, compContainers.size(), "num comps");
     compContainers.forEach(item -> {
-      Assert.assertEquals("num containers", 2, item.getContainers().size());
+      Assertions.assertEquals(2, item.getContainers().size(), "num containers");
     });
 
     reqBuilder.clearContainerStates();
     reqBuilder.addAllContainerStates(Lists.newArrayList(
         ContainerState.STOPPED.toString()));
-    Assert.assertEquals("num comps", 0,
-        FilterUtils.filterInstances(sc, reqBuilder.build()).size());
+    Assertions.assertEquals(0
+,         FilterUtils.filterInstances(sc, reqBuilder.build()).size(), "num comps");
   }
 
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-applications/hadoop-yarn-services/hadoop-yarn-services-core/src/test/java/org/apache/hadoop/yarn/service/utils/TestServiceApiUtil.java
@@ -32,9 +32,10 @@ import org.apache.hadoop.yarn.service.api.records.Resource;
 import org.apache.hadoop.yarn.service.api.records.Service;
 import org.apache.hadoop.yarn.service.api.records.ServiceState;
 import org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +50,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
 import static org.apache.hadoop.yarn.service.conf.RestApiConstants.DEFAULT_UNLIMITED_LIFETIME;
 import static org.apache.hadoop.yarn.service.exceptions.RestApiErrorMessages.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for ServiceApiUtil helper methods.
@@ -72,12 +73,13 @@ public class TestServiceApiUtil extends ServiceTestUtils {
   private static final YarnConfiguration CONF_DNS_ENABLED = new
       YarnConfiguration();
 
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     CONF_DNS_ENABLED.setBoolean(RegistryConstants.KEY_DNS_ENABLED, true);
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90)
   public void testResourceValidation() throws Exception {
     assertEquals(RegistryConstants.MAX_FQDN_LABEL_LENGTH + 1, LEN_64_STR
         .length());
@@ -89,7 +91,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no name");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no name");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_APPLICATION_NAME_INVALID, e.getMessage());
     }
@@ -98,7 +100,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // no version
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + " service with no version");
+      Assertions.fail(EXCEPTION_PREFIX + " service with no version");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_APPLICATION_VERSION_INVALID,
           app.getName()), e.getMessage());
@@ -111,7 +113,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       app.setName(badName);
       try {
         ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-        Assert.fail(EXCEPTION_PREFIX + "service with bad name " + badName);
+        Assertions.fail(EXCEPTION_PREFIX + "service with bad name " + badName);
       } catch (IllegalArgumentException e) {
 
       }
@@ -123,7 +125,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.addComponent(comp);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
-      Assert.fail(EXCEPTION_PREFIX + "service with no launch command");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -134,7 +136,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
         .MAX_FQDN_LABEL_LENGTH));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no launch command");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no launch command");
     } catch (IllegalArgumentException e) {
       assertEquals(RestApiErrorMessages.ERROR_ABSENT_LAUNCH_COMMAND,
           e.getMessage());
@@ -146,7 +148,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setResource(res);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no memory");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_RESOURCE_MEMORY_FOR_COMP_INVALID,
@@ -158,7 +160,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(-2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(
+      Assertions.fail(
           EXCEPTION_PREFIX + "service with invalid no of cpus");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
@@ -170,9 +172,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setCpus(2);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no container count");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no container count");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      Assertions.assertTrue(e.getMessage()
           .contains(ERROR_CONTAINERS_COUNT_INVALID));
     }
 
@@ -180,7 +182,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setProfile("hbase_finance_large");
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX
+      Assertions.fail(EXCEPTION_PREFIX
           + "service with resource profile along with cpus/memory");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
@@ -195,7 +197,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     res.setMemory(null);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with resource profile only");
+      Assertions.fail(EXCEPTION_PREFIX + "service with resource profile only");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_RESOURCE_PROFILE_NOT_SUPPORTED_YET,
           e.getMessage());
@@ -209,9 +211,9 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // null number of containers
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "null number of containers");
+      Assertions.fail(EXCEPTION_PREFIX + "null number of containers");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      Assertions.assertTrue(e.getMessage()
           .startsWith(ERROR_CONTAINERS_COUNT_INVALID));
     }
   }
@@ -236,7 +238,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     app.setComponents(Collections.singletonList(comp));
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -246,7 +248,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.SERVICE);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(ERROR_ARTIFACT_ID_INVALID, e.getMessage());
     }
@@ -255,7 +257,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     artifact.setType(Artifact.TypeEnum.TARBALL);
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with no artifact id");
+      Assertions.fail(EXCEPTION_PREFIX + "service with no artifact id");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(ERROR_ARTIFACT_ID_FOR_COMP_INVALID, compName),
           e.getMessage());
@@ -268,7 +270,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
       LOG.error("service attributes specified should be valid here", e);
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertThat(app.getLifetime()).isEqualTo(DEFAULT_UNLIMITED_LIFETIME);
@@ -315,7 +317,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -333,7 +335,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // duplicate component name fails
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with component collision");
+      Assertions.fail(EXCEPTION_PREFIX + "service with component collision");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name collision: " + compName, e.getMessage());
     }
@@ -350,7 +352,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     //component name same as service name
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "component name matches service name");
+      Assertions.fail(EXCEPTION_PREFIX + "component name matches service name");
     } catch (IllegalArgumentException e) {
       assertEquals("Component name test must not be same as service name test",
           e.getMessage());
@@ -372,7 +374,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -390,7 +392,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -403,7 +405,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     assertEquals(1, app.getComponents().size());
@@ -440,7 +442,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     c.setDependencies(Arrays.asList("e"));
     try {
       verifyDependencySorting(Arrays.asList(a, b, c, d, e));
-      Assert.fail(EXCEPTION_PREFIX + "components with dependency cycle");
+      Assertions.fail(EXCEPTION_PREFIX + "components with dependency cycle");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_CYCLE, Arrays.asList(c, d,
@@ -453,7 +455,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(service, sfs,
           CONF_DEFAULT_DNS);
-      Assert.fail(EXCEPTION_PREFIX + "components with bad dependencies");
+      Assertions.fail(EXCEPTION_PREFIX + "components with bad dependencies");
     } catch (IllegalArgumentException ex) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_DEPENDENCY_INVALID, "b", "e"), ex
@@ -476,7 +478,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     for (String name : invalidNames) {
       try {
         ServiceApiUtil.validateNameFormat(name, new Configuration());
-        Assert.fail();
+        Assertions.fail();
       } catch (IllegalArgumentException ex) {
         ex.printStackTrace();
       }
@@ -496,7 +498,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     // invalid component name fails if dns is enabled
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "service with invalid component name");
+      Assertions.fail(EXCEPTION_PREFIX + "service with invalid component name");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(RestApiErrorMessages
           .ERROR_COMPONENT_NAME_INVALID, maxLen, compName), e.getMessage());
@@ -506,7 +508,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DEFAULT_DNS);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     compName = LEN_64_STR.substring(0, maxLen);
@@ -517,7 +519,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -534,7 +536,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "constraint with no type");
+      Assertions.fail(EXCEPTION_PREFIX + "constraint with no type");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_TYPE_NULL,
@@ -546,7 +548,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
-      Assert.fail(EXCEPTION_PREFIX + "constraint with no scope");
+      Assertions.fail(EXCEPTION_PREFIX + "constraint with no scope");
     } catch (IllegalArgumentException e) {
       assertEquals(String.format(
           RestApiErrorMessages.ERROR_PLACEMENT_POLICY_CONSTRAINT_SCOPE_NULL,
@@ -564,7 +566,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateAndResolveService(app, sfs, CONF_DNS_ENABLED);
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -581,7 +583,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     // Keytab with no URI scheme should succeed too
@@ -589,7 +591,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -602,7 +604,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
 
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
-      Assert.fail(EXCEPTION_PREFIX + "service with invalid principal name " +
+      Assertions.fail(EXCEPTION_PREFIX + "service with invalid principal name " +
           "format.");
     } catch (IllegalArgumentException e) {
       assertEquals(
@@ -616,7 +618,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (IllegalArgumentException e) {
-      Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+      Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
 
     kp.setPrincipalName(null);
@@ -624,7 +626,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     try {
       ServiceApiUtil.validateKerberosPrincipal(app.getKerberosPrincipal());
     } catch (NullPointerException e) {
-        Assert.fail(NO_EXCEPTION_PREFIX + e.getMessage());
+        Assertions.fail(NO_EXCEPTION_PREFIX + e.getMessage());
     }
   }
 
@@ -643,8 +645,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compb");
     expected.add("compa");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -663,8 +665,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -686,8 +688,8 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
@@ -703,12 +705,13 @@ public class TestServiceApiUtil extends ServiceTestUtils {
     expected.add("compa");
     expected.add("compb");
     for (int i = 0; i < expected.size(); i++) {
-      Assert.assertEquals("Components are not equal.", expected.get(i),
-          order.get(i));
+      Assertions.assertEquals(expected.get(i)
+,           order.get(i), "Components are not equal.");
     }
   }
 
-  @Test(timeout = 1500)
+  @Test
+  @Timeout(value = 1)
   public void testNoServiceDependencies() {
     Service service = createExampleApplication();
     Component compa = createComponent("compa");
@@ -743,7 +746,7 @@ public class TestServiceApiUtil extends ServiceTestUtils {
       Thread.sleep(1000);
     } catch (InterruptedException e) {
     }
-    Assert.assertTrue(thread.isAlive());
+    Assertions.assertTrue(thread.isAlive());
   }
 
   @Test


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11243. Upgrade JUnit from 4 to 5 in hadoop-yarn-applications.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

