### PR TITLE
YARN-11244. Upgrade JUnit from 4 to 5 in hadoop-yarn-client.

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/ApplicationMasterServiceProtoTestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/ApplicationMasterServiceProtoTestBase.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.ApplicationMasterProtocol;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * Test Base for Application Master Service Protocol.
@@ -52,7 +52,7 @@ public abstract class ApplicationMasterServiceProtoTestBase
         .createRMProxy(this.conf, ApplicationMasterProtocol.class);
   }
 
-  @After
+  @AfterEach
   public void shutDown() {
     if(this.amClient != null) {
       RPC.stopProxy(this.amClient);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/ProtocolHATestBase.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/ProtocolHATestBase.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterReque
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
 import org.apache.hadoop.yarn.api.records.CollectorInfo;
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.yarn.server.resourcemanager.HATestUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.ha.ClientBaseWithFixes;
@@ -128,8 +128,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.security.RMContainerTokenSe
 import org.apache.hadoop.yarn.server.resourcemanager.security.RMDelegationTokenSecretManager;
 import org.apache.hadoop.yarn.server.security.ApplicationACLsManager;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 
 /**
@@ -164,7 +164,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
   protected Thread failoverThread = null;
   private volatile boolean keepRunning;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     failoverThread = null;
     keepRunning = true;
@@ -181,7 +181,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
     conf.setBoolean(YarnConfiguration.YARN_MINICLUSTER_USE_RPC, true);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     keepRunning = false;
     if (failoverThread != null) {
@@ -205,8 +205,8 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
     int newActiveRMIndex = (activeRMIndex + 1) % 2;
     getAdminService(activeRMIndex).transitionToStandby(req);
     getAdminService(newActiveRMIndex).transitionToActive(req);
-    assertEquals("Failover failed", newActiveRMIndex,
-        cluster.getActiveRMIndex());
+    assertEquals(newActiveRMIndex
+,         cluster.getActiveRMIndex(), "Failover failed");
   }
 
   protected YarnClient createAndStartYarnClient(Configuration conf) {
@@ -219,8 +219,8 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
 
   protected void verifyConnections() throws InterruptedException,
       YarnException {
-    assertTrue("NMs failed to connect to the RM",
-        cluster.waitForNodeManagersToConnect(5000));
+    assertTrue(
+       cluster.waitForNodeManagersToConnect(5000), "NMs failed to connect to the RM");
     verifyClientConnection();
   }
 
@@ -284,7 +284,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
     cluster.resetStartFailoverFlag(false);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     // Do the failover
@@ -406,7 +406,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // create the GetNewApplicationResponse with fake applicationId
         GetNewApplicationResponse response =
@@ -421,7 +421,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // create a fake application report
         ApplicationReport report = createFakeAppReport();
@@ -436,7 +436,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // create GetClusterMetricsResponse with fake YarnClusterMetrics
         GetClusterMetricsResponse response =
@@ -451,7 +451,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // create GetApplicationsResponse with fake applicationList
         GetApplicationsResponse response =
@@ -466,7 +466,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // create GetClusterNodesResponse with fake ClusterNodeLists
         GetClusterNodesResponse response =
@@ -480,7 +480,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake QueueInfo
         return GetQueueInfoResponse.newInstance(createFakeQueueInfo());
@@ -492,7 +492,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake queueUserAcls
         return GetQueueUserAclsInfoResponse
@@ -506,7 +506,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake ApplicationAttemptReport
         return GetApplicationAttemptReportResponse
@@ -520,7 +520,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake ApplicationAttemptReports
         return GetApplicationAttemptsResponse
@@ -534,7 +534,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake containerReport
         return GetContainerReportResponse
@@ -547,7 +547,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         // return fake ContainerReports
         return GetContainersResponse.newInstance(createFakeContainerReports());
@@ -559,7 +559,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return super.submitApplication(request);
       }
@@ -570,7 +570,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return KillApplicationResponse.newInstance(true);
       }
@@ -581,7 +581,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return Records.newRecord(MoveApplicationAcrossQueuesResponse.class);
       }
@@ -592,7 +592,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return GetDelegationTokenResponse.newInstance(createFakeToken());
       }
@@ -603,7 +603,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return RenewDelegationTokenResponse
             .newInstance(createNextExpirationTime());
@@ -615,7 +615,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
         resetStartFailoverFlag(true);
 
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
 
         return CancelDelegationTokenResponse.newInstance();
       }
@@ -741,7 +741,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
           IOException {
         resetStartFailoverFlag(true);
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
         return super.registerNodeManager(request);
       }
 
@@ -750,7 +750,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
           throws YarnException, IOException {
         resetStartFailoverFlag(true);
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
         return super.nodeHeartbeat(request);
       }
     }
@@ -767,7 +767,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
           throws YarnException, IOException {
         resetStartFailoverFlag(true);
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
         return createFakeAllocateResponse();
       }
 
@@ -777,7 +777,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
           IOException {
         resetStartFailoverFlag(true);
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
         return createFakeRegisterApplicationMasterResponse();
       }
 
@@ -787,7 +787,7 @@ public abstract class ProtocolHATestBase extends ClientBaseWithFixes {
           IOException {
         resetStartFailoverFlag(true);
         // make sure failover has been triggered
-        Assert.assertTrue(waittingForFailOver());
+        Assertions.assertTrue(waittingForFailOver());
         return createFakeFinishApplicationMasterResponse();
       }
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationClientProtocolOnHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationClientProtocolOnHA.java
@@ -42,24 +42,24 @@ import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
   private YarnClient client = null;
 
-  @Before
+  @BeforeEach
   public void initiate() throws Exception {
     startHACluster(1, true, false, false);
     Configuration conf = new YarnConfiguration(this.conf);
     client = createAndStartYarnClient(conf);
   }
 
-  @After
+  @AfterEach
   public void shutDown() {
     if (client != null) {
       client.stop();
@@ -73,8 +73,8 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
   public void testGetApplicationReportOnHA() throws Exception {
     ApplicationReport report =
         client.getApplicationReport(cluster.createFakeAppId());
-    Assert.assertTrue(report != null);
-    Assert.assertEquals(cluster.createFakeAppReport(), report);
+    Assertions.assertTrue(report != null);
+    Assertions.assertEquals(cluster.createFakeAppReport(), report);
   }
 
   @Test
@@ -82,16 +82,16 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
     ApplicationId appId =
         client.createApplication().getApplicationSubmissionContext()
             .getApplicationId();
-    Assert.assertTrue(appId != null);
-    Assert.assertEquals(cluster.createFakeAppId(), appId);
+    Assertions.assertTrue(appId != null);
+    Assertions.assertEquals(cluster.createFakeAppId(), appId);
   }
 
   @Test
   public void testGetClusterMetricsOnHA() throws Exception {
     YarnClusterMetrics clusterMetrics =
         client.getYarnClusterMetrics();
-    Assert.assertTrue(clusterMetrics != null);
-    Assert.assertEquals(cluster.createFakeYarnClusterMetrics(),
+    Assertions.assertTrue(clusterMetrics != null);
+    Assertions.assertEquals(cluster.createFakeYarnClusterMetrics(),
         clusterMetrics);
   }
 
@@ -99,35 +99,35 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
   public void testGetApplicationsOnHA() throws Exception {
     List<ApplicationReport> reports =
         client.getApplications();
-    Assert.assertTrue(reports != null);
-    Assert.assertFalse(reports.isEmpty());
-    Assert.assertEquals(cluster.createFakeAppReports(),
+    Assertions.assertTrue(reports != null);
+    Assertions.assertFalse(reports.isEmpty());
+    Assertions.assertEquals(cluster.createFakeAppReports(),
         reports);
   }
 
   @Test
   public void testGetClusterNodesOnHA() throws Exception {
     List<NodeReport> reports = client.getNodeReports(NodeState.RUNNING);
-    Assert.assertTrue(reports != null);
-    Assert.assertFalse(reports.isEmpty());
-    Assert.assertEquals(cluster.createFakeNodeReports(),
+    Assertions.assertTrue(reports != null);
+    Assertions.assertFalse(reports.isEmpty());
+    Assertions.assertEquals(cluster.createFakeNodeReports(),
         reports);
   }
 
   @Test
   public void testGetQueueInfoOnHA() throws Exception {
     QueueInfo queueInfo = client.getQueueInfo("root");
-    Assert.assertTrue(queueInfo != null);
-    Assert.assertEquals(cluster.createFakeQueueInfo(),
+    Assertions.assertTrue(queueInfo != null);
+    Assertions.assertEquals(cluster.createFakeQueueInfo(),
         queueInfo);
   }
 
   @Test
   public void testGetQueueUserAclsOnHA() throws Exception {
     List<QueueUserACLInfo> queueUserAclsList = client.getQueueAclsInfo();
-    Assert.assertTrue(queueUserAclsList != null);
-    Assert.assertFalse(queueUserAclsList.isEmpty());
-    Assert.assertEquals(cluster.createFakeQueueUserACLInfoList(),
+    Assertions.assertTrue(queueUserAclsList != null);
+    Assertions.assertFalse(queueUserAclsList.isEmpty());
+    Assertions.assertEquals(cluster.createFakeQueueUserACLInfoList(),
         queueUserAclsList);
   }
 
@@ -136,17 +136,17 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
     ApplicationAttemptReport report =
         client.getApplicationAttemptReport(cluster
             .createFakeApplicationAttemptId());
-    Assert.assertTrue(report != null);
-    Assert.assertEquals(cluster.createFakeApplicationAttemptReport(), report);
+    Assertions.assertTrue(report != null);
+    Assertions.assertEquals(cluster.createFakeApplicationAttemptReport(), report);
   }
 
   @Test
   public void testGetApplicationAttemptsOnHA() throws Exception {
     List<ApplicationAttemptReport> reports =
         client.getApplicationAttempts(cluster.createFakeAppId());
-    Assert.assertTrue(reports != null);
-    Assert.assertFalse(reports.isEmpty());
-    Assert.assertEquals(cluster.createFakeApplicationAttemptReports(),
+    Assertions.assertTrue(reports != null);
+    Assertions.assertFalse(reports.isEmpty());
+    Assertions.assertEquals(cluster.createFakeApplicationAttemptReports(),
         reports);
   }
 
@@ -154,17 +154,17 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
   public void testGetContainerReportOnHA() throws Exception {
     ContainerReport report =
         client.getContainerReport(cluster.createFakeContainerId());
-    Assert.assertTrue(report != null);
-    Assert.assertEquals(cluster.createFakeContainerReport(), report);
+    Assertions.assertTrue(report != null);
+    Assertions.assertEquals(cluster.createFakeContainerReport(), report);
   }
 
   @Test
   public void testGetContainersOnHA() throws Exception {
     List<ContainerReport> reports =
         client.getContainers(cluster.createFakeApplicationAttemptId());
-    Assert.assertTrue(reports != null);
-    Assert.assertFalse(reports.isEmpty());
-    Assert.assertEquals(cluster.createFakeContainerReports(),
+    Assertions.assertTrue(reports != null);
+    Assertions.assertFalse(reports.isEmpty());
+    Assertions.assertEquals(cluster.createFakeContainerReports(),
         reports);
   }
 
@@ -181,7 +181,7 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
     capability.setVirtualCores(1);
     appContext.setResource(capability);
     ApplicationId appId = client.submitApplication(appContext);
-    Assert.assertTrue(getActiveRM().getRMContext().getRMApps()
+    Assertions.assertTrue(getActiveRM().getRMContext().getRMApps()
         .containsKey(appId));
   }
 
@@ -198,7 +198,7 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
   @Test
   public void testGetDelegationTokenOnHA() throws Exception {
     Token token = client.getRMDelegationToken(new Text(" "));
-    Assert.assertEquals(token, cluster.createFakeToken());
+    Assertions.assertEquals(token, cluster.createFakeToken());
   }
 
   @Test
@@ -208,7 +208,7 @@ public class TestApplicationClientProtocolOnHA extends ProtocolHATestBase {
     long newExpirationTime =
         ClientRMProxy.createRMProxy(this.conf, ApplicationClientProtocol.class)
             .renewDelegationToken(request).getNextExpirationTime();
-    Assert.assertEquals(newExpirationTime, cluster.createNextExpirationTime());
+    Assertions.assertEquals(newExpirationTime, cluster.createNextExpirationTime());
   }
 
   @Test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolForTimelineV2.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolForTimelineV2.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.resourcemanager.HATestUtil;
 import org.apache.hadoop.yarn.server.timelineservice.storage.FileSystemTimelineWriterImpl;
 import org.apache.hadoop.yarn.server.timelineservice.storage.TimelineWriter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 /**
@@ -45,7 +45,7 @@ public class TestApplicationMasterServiceProtocolForTimelineV2
 
   public Timeout timeout = new Timeout(180, TimeUnit.SECONDS);
 
-  @Before
+  @BeforeEach
   public void initialize() throws Exception {
     HATestUtil.setRpcAddressForRM(RM1_NODE_ID, RM1_PORT_BASE + 200, conf);
     HATestUtil.setRpcAddressForRM(RM2_NODE_ID, RM2_PORT_BASE + 200, conf);
@@ -66,10 +66,10 @@ public class TestApplicationMasterServiceProtocolForTimelineV2
         ResourceBlacklistRequest.newInstance(new ArrayList<String>(),
             new ArrayList<String>()));
     AllocateResponse response = getAMClient().allocate(request);
-    Assert.assertEquals(response, this.cluster.createFakeAllocateResponse());
-    Assert.assertNotNull(response.getCollectorInfo());
-    Assert.assertEquals("host:port",
+    Assertions.assertEquals(response, this.cluster.createFakeAllocateResponse());
+    Assertions.assertNotNull(response.getCollectorInfo());
+    Assertions.assertEquals("host:port",
         response.getCollectorInfo().getCollectorAddr());
-    Assert.assertNotNull(response.getCollectorInfo().getCollectorToken());
+    Assertions.assertNotNull(response.getCollectorInfo().getCollectorToken());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolOnHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestApplicationMasterServiceProtocolOnHA.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
@@ -35,9 +35,9 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ResourceBlacklistRequest;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 
@@ -46,7 +46,7 @@ public class TestApplicationMasterServiceProtocolOnHA
   @Rule
   public Timeout timeout = new Timeout(180, TimeUnit.SECONDS);
 
-  @Before
+  @BeforeEach
   public void initialize() throws Exception {
     startHACluster(0, false, false, true);
     super.startupHAAndSetupClient();
@@ -59,7 +59,7 @@ public class TestApplicationMasterServiceProtocolOnHA
         RegisterApplicationMasterRequest.newInstance("localhost", 0, "");
     RegisterApplicationMasterResponse response =
         getAMClient().registerApplicationMaster(request);
-    Assert.assertEquals(response,
+    Assertions.assertEquals(response,
         this.cluster.createFakeRegisterApplicationMasterResponse());
   }
 
@@ -71,7 +71,7 @@ public class TestApplicationMasterServiceProtocolOnHA
             FinalApplicationStatus.SUCCEEDED, "", "");
     FinishApplicationMasterResponse response =
         getAMClient().finishApplicationMaster(request);
-    Assert.assertEquals(response,
+    Assertions.assertEquals(response,
         this.cluster.createFakeFinishApplicationMasterResponse());
   }
 
@@ -83,6 +83,6 @@ public class TestApplicationMasterServiceProtocolOnHA
         ResourceBlacklistRequest.newInstance(new ArrayList<String>(),
             new ArrayList<String>()));
     AllocateResponse response = getAMClient().allocate(request);
-    Assert.assertEquals(response, this.cluster.createFakeAllocateResponse());
+    Assertions.assertEquals(response, this.cluster.createFakeAllocateResponse());
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestFederationRMFailoverProxyProvider.java
@@ -44,10 +44,11 @@ import org.apache.hadoop.yarn.server.federation.store.records.SubClusterState;
 import org.apache.hadoop.yarn.server.federation.utils.FederationStateStoreFacade;
 import org.apache.hadoop.yarn.server.resourcemanager.HATestUtil;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
@@ -68,7 +69,7 @@ public class TestFederationRMFailoverProxyProvider {
 
   private GetClusterMetricsResponse threadResponse;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, YarnException {
     conf = new YarnConfiguration();
 
@@ -82,18 +83,20 @@ public class TestFederationRMFailoverProxyProvider {
         .getSubClusters(any(GetSubClustersInfoRequest.class));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     stateStore.close();
     stateStore = null;
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testFederationRMFailoverProxyProvider() throws Exception {
     testProxyProvider(true);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testFederationRMFailoverProxyProviderWithoutFlushFacadeCache()
       throws Exception {
     testProxyProvider(false);
@@ -203,8 +206,8 @@ public class TestFederationRMFailoverProxyProvider {
   }
 
   private void checkResponse(GetClusterMetricsResponse response) {
-    Assert.assertNotNull(response.getClusterMetrics());
-    Assert.assertEquals(0,
+    Assertions.assertNotNull(response.getClusterMetrics());
+    Assertions.assertEquals(0,
         response.getClusterMetrics().getNumActiveNodeManagers());
   }
 
@@ -267,7 +270,7 @@ public class TestFederationRMFailoverProxyProvider {
     });
 
     final ProxyInfo currentProxy = provider.getProxy();
-    Assert.assertEquals("user1", provider.getLastProxyUGI().getUserName());
+    Assertions.assertEquals("user1", provider.getLastProxyUGI().getUserName());
 
     user2.doAs(new PrivilegedExceptionAction<Object>() {
       @Override
@@ -276,7 +279,7 @@ public class TestFederationRMFailoverProxyProvider {
         return null;
       }
     });
-    Assert.assertEquals("user1", provider.getLastProxyUGI().getUserName());
+    Assertions.assertEquals("user1", provider.getLastProxyUGI().getUserName());
 
     provider.close();
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestGetGroups.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestGetGroups.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.tools.GetGroupsTestBase;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class TestGetGroups extends GetGroupsTestBase {
   
   private static Configuration conf;
   
-  @BeforeClass
+  @BeforeAll
   public static void setUpResourceManager() throws InterruptedException {
     conf = new YarnConfiguration();
     resourceManager = new ResourceManager() {
@@ -77,19 +77,19 @@ public class TestGetGroups extends GetGroupsTestBase {
     }.start();
 
     boolean rmStarted = rmStartedSignal.await(60000L, TimeUnit.MILLISECONDS);
-    Assert.assertTrue("ResourceManager failed to start up.", rmStarted);
+    Assertions.assertTrue(rmStarted, "ResourceManager failed to start up.");
 
     LOG.info("ResourceManager RMAdmin address: {}.",
         conf.get(YarnConfiguration.RM_ADMIN_ADDRESS));
   }
   
   @SuppressWarnings("static-access")
-  @Before
+  @BeforeEach
   public void setUpConf() {
     super.conf = this.conf;
   }
   
-  @AfterClass
+  @AfterAll
   public static void tearDownResourceManager() throws InterruptedException {
     if (resourceManager != null) {
       LOG.info("Stopping ResourceManager...");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestHedgingRequestRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestHedgingRequestRMFailoverProxyProvider.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
 import org.apache.hadoop.yarn.server.resourcemanager.HATestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestHedgingRequestRMFailoverProxyProvider {
 
@@ -73,7 +73,7 @@ public class TestHedgingRequestRMFailoverProxyProvider {
       long end = System.currentTimeMillis();
       System.out.println("Client call succeeded at " + end);
       // should return the response fast
-      Assert.assertTrue(end - start <= 10000);
+      Assertions.assertTrue(end - start <= 10000);
 
       // transition rm5 to standby
       cluster.getResourceManager(4).getRMContext().getRMAdminService()
@@ -92,15 +92,15 @@ public class TestHedgingRequestRMFailoverProxyProvider {
     try {
       // client will retry until the rm becomes active.
       client.getApplicationReport(null);
-      Assert.fail();
+      Assertions.fail();
     } catch (YarnException e) {
-      Assert.assertTrue(e instanceof ApplicationNotFoundException);
+      Assertions.assertTrue(e instanceof ApplicationNotFoundException);
     }
     // now make a valid call.
     try {
       client.getAllQueues();
     } catch (YarnException e) {
-      Assert.fail(e.toString());
+      Assertions.fail(e.toString());
     }
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestMemoryPageUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestMemoryPageUtils.java
@@ -18,12 +18,12 @@
 package org.apache.hadoop.yarn.client;
 
 import org.apache.hadoop.yarn.client.util.MemoryPageUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * The purpose of this class is to test

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestNoHaRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestNoHaRMFailoverProxyProvider.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.MiniYARNCluster;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -65,7 +65,7 @@ public class TestNoHaRMFailoverProxyProvider {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, YarnException {
     conf = new YarnConfiguration();
   }
@@ -88,8 +88,8 @@ public class TestNoHaRMFailoverProxyProvider {
       rmClient.start();
       List <NodeReport> nodeReports = rmClient.getNodeReports();
       assertEquals(
-          "The proxy didn't get expected number of node reports",
-          NUMNODEMANAGERS, nodeReports.size());
+      
+         NUMNODEMANAGERS, nodeReports.size(), "The proxy didn't get expected number of node reports");
     } finally {
       if (rmClient != null) {
         rmClient.stop();
@@ -119,8 +119,8 @@ public class TestNoHaRMFailoverProxyProvider {
       rmClient.start();
       List <NodeReport> nodeReports = rmClient.getNodeReports();
       assertEquals(
-          "The proxy didn't get expected number of node reports",
-          NUMNODEMANAGERS, nodeReports.size());
+      
+         NUMNODEMANAGERS, nodeReports.size(), "The proxy didn't get expected number of node reports");
     } finally {
       if (rmClient != null) {
         rmClient.stop();
@@ -156,22 +156,22 @@ public class TestNoHaRMFailoverProxyProvider {
     fpp.init(conf, mockRMProxy, protocol);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // Invoke fpp.getProxy() multiple times and
     // validate the returned proxy is always mockProxy1
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // verify that mockRMProxy.getProxy() is invoked once only.
     verify(mockRMProxy, times(1))
@@ -181,9 +181,9 @@ public class TestNoHaRMFailoverProxyProvider {
     // Perform Failover and get proxy again from failover proxy provider
     fpp.performFailover(actualProxy1.proxy);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy2 = fpp.getProxy();
-    assertEquals("AutoRefreshRMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy1, actualProxy2.proxy);
+    assertEquals(
+       mockProxy1, actualProxy2.proxy, "AutoRefreshRMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // verify that mockRMProxy.getProxy() didn't get invoked again after
     // performFailover()
@@ -226,22 +226,22 @@ public class TestNoHaRMFailoverProxyProvider {
     fpp.init(conf, mockRMProxy, protocol);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // Invoke fpp.getProxy() multiple times and
     // validate the returned proxy is always mockProxy1
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // verify that mockRMProxy.getProxy() is invoked once only.
     verify(mockRMProxy, times(1))
@@ -260,13 +260,13 @@ public class TestNoHaRMFailoverProxyProvider {
     // Perform Failover and get proxy again from failover proxy provider
     fpp.performFailover(actualProxy1.proxy);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy2 = fpp.getProxy();
-    assertEquals("AutoRefreshNoHARMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy2, actualProxy2.proxy);
+    assertEquals(
+       mockProxy2, actualProxy2.proxy, "AutoRefreshNoHARMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // check the proxy is different with the one we created before.
-    assertNotEquals("AutoRefreshNoHARMFailoverProxyProvider " +
-        "shouldn't generate same proxy after failover",
-        actualProxy1.proxy, actualProxy2.proxy);
+    assertNotEquals(
+       actualProxy1.proxy, actualProxy2.proxy, "AutoRefreshNoHARMFailoverProxyProvider " +
+        "shouldn't generate same proxy after failover");
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailover.java
@@ -18,12 +18,12 @@
 
 package org.apache.hadoop.yarn.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -56,10 +56,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.RMFatalEvent;
 import org.apache.hadoop.yarn.server.resourcemanager.RMFatalEventType;
 import org.apache.hadoop.yarn.server.webproxy.WebAppProxyServer;
 import org.apache.hadoop.yarn.webapp.YarnWebParams;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -81,7 +81,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
   private MiniYARNCluster cluster;
   private ApplicationId fakeAppId;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     fakeAppId = ApplicationId.newInstance(System.currentTimeMillis(), 0);
     conf = new YarnConfiguration();
@@ -98,7 +98,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     cluster = new MiniYARNCluster(TestRMFailover.class.getName(), 2, 1, 1, 1);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.stop();
   }
@@ -123,8 +123,8 @@ public class TestRMFailover extends ClientBaseWithFixes {
   }
 
   private void verifyConnections() throws InterruptedException, YarnException {
-    assertTrue("NMs failed to connect to the RM",
-        cluster.waitForNodeManagersToConnect(20000));
+    assertTrue(
+       cluster.waitForNodeManagersToConnect(20000), "NMs failed to connect to the RM");
     verifyClientConnection();
   }
 
@@ -137,15 +137,15 @@ public class TestRMFailover extends ClientBaseWithFixes {
     int newActiveRMIndex = (activeRMIndex + 1) % 2;
     getAdminService(activeRMIndex).transitionToStandby(req);
     getAdminService(newActiveRMIndex).transitionToActive(req);
-    assertEquals("Failover failed", newActiveRMIndex, cluster.getActiveRMIndex());
+    assertEquals(newActiveRMIndex, cluster.getActiveRMIndex(), "Failover failed");
   }
 
   private void failover()
       throws IOException, InterruptedException, YarnException {
     int activeRMIndex = cluster.getActiveRMIndex();
     cluster.stopResourceManager(activeRMIndex);
-    assertEquals("Failover failed",
-        (activeRMIndex + 1) % 2, cluster.getActiveRMIndex());
+    assertEquals(
+       (activeRMIndex + 1) % 2, cluster.getActiveRMIndex(), "Failover failed");
     cluster.restartResourceManager(activeRMIndex);
   }
 
@@ -155,7 +155,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     explicitFailover();
@@ -189,7 +189,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
 
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     failover();
@@ -220,14 +220,14 @@ public class TestRMFailover extends ClientBaseWithFixes {
       cluster.init(conf);
       cluster.start();
       getAdminService(0).transitionToActive(req);
-      assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+      assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
       verifyConnections();
       webAppProxyServer.init(conf);
 
       // Start webAppProxyServer
-      Assert.assertEquals(STATE.INITED, webAppProxyServer.getServiceState());
+      Assertions.assertEquals(STATE.INITED, webAppProxyServer.getServiceState());
       webAppProxyServer.start();
-      Assert.assertEquals(STATE.STARTED, webAppProxyServer.getServiceState());
+      Assertions.assertEquals(STATE.STARTED, webAppProxyServer.getServiceState());
 
       // send httpRequest with fakeApplicationId
       // expect to get "Not Found" response and 404 response code
@@ -253,7 +253,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.setBoolean(YarnConfiguration.AUTO_FAILOVER_ENABLED, false);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
     verifyConnections();
 
     // send httpRequest with fakeApplicationId
@@ -391,7 +391,7 @@ public class TestRMFailover extends ClientBaseWithFixes {
     conf.set(YarnConfiguration.RM_ZK_ADDRESS, hostPort);
     cluster.init(conf);
     cluster.start();
-    assertFalse("RM never turned active", -1 == cluster.getActiveRMIndex());
+    assertFalse(-1 == cluster.getActiveRMIndex(), "RM never turned active");
 
     ResourceManager resourceManager = cluster.getResourceManager(
         cluster.getActiveRMIndex());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailoverProxyProvider.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestRMFailoverProxyProvider.java
@@ -23,8 +23,8 @@ import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,9 +33,9 @@ import java.lang.reflect.Proxy;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
@@ -68,7 +68,7 @@ public class TestRMFailoverProxyProvider {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, YarnException {
     conf = new YarnConfiguration();
     conf.setClass(YarnConfiguration.CLIENT_FAILOVER_NO_HA_PROXY_PROVIDER,
@@ -111,22 +111,22 @@ public class TestRMFailoverProxyProvider {
     fpp.init(conf, mockRMProxy, protocol);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy1 = fpp.getProxy();
     assertEquals(
-        "ConfiguredRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "ConfiguredRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // Invoke fpp.getProxy() multiple times and
     // validate the returned proxy is always mockProxy1
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "ConfiguredRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "ConfiguredRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "ConfiguredRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "ConfiguredRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // verify that mockRMProxy.getProxy() is invoked once only.
     verify(mockRMProxy, times(1))
@@ -145,14 +145,14 @@ public class TestRMFailoverProxyProvider {
     // Perform Failover and get proxy again from failover proxy provider
     fpp.performFailover(actualProxy1.proxy);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy2 = fpp.getProxy();
-    assertEquals("ConfiguredRMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy2, actualProxy2.proxy);
+    assertEquals(
+       mockProxy2, actualProxy2.proxy, "ConfiguredRMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // check the proxy is different with the one we created before.
-    assertNotEquals("ConfiguredRMFailoverProxyProvider " +
-        "shouldn't generate same proxy after failover",
-        actualProxy1.proxy, actualProxy2.proxy);
+    assertNotEquals(
+       actualProxy1.proxy, actualProxy2.proxy, "ConfiguredRMFailoverProxyProvider " +
+        "shouldn't generate same proxy after failover");
 
     // verify that mockRMProxy.getProxy() has been one with each address
     verify(mockRMProxy, times(1))
@@ -175,9 +175,9 @@ public class TestRMFailoverProxyProvider {
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy3 = fpp.getProxy();
 
     // check the proxy is the same as the one we created before.
-    assertEquals("ConfiguredRMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy1, actualProxy3.proxy);
+    assertEquals(
+       mockProxy1, actualProxy3.proxy, "ConfiguredRMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // verify that mockRMProxy.getProxy() has still only been invoked twice
     verify(mockRMProxy, times(1))
@@ -229,22 +229,22 @@ public class TestRMFailoverProxyProvider {
     fpp.init(conf, mockRMProxy, protocol);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // Invoke fpp.getProxy() multiple times and
     // validate the returned proxy is always mockProxy1
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
     actualProxy1 = fpp.getProxy();
     assertEquals(
-        "AutoRefreshRMFailoverProxyProvider doesn't generate " +
-        "expected proxy",
-        mockProxy1, actualProxy1.proxy);
+    
+       mockProxy1, actualProxy1.proxy, "AutoRefreshRMFailoverProxyProvider doesn't generate " +
+        "expected proxy");
 
     // verify that mockRMProxy.getProxy() is invoked once only.
     verify(mockRMProxy, times(1))
@@ -263,14 +263,14 @@ public class TestRMFailoverProxyProvider {
     // Perform Failover and get proxy again from failover proxy provider
     fpp.performFailover(actualProxy1.proxy);
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy2 = fpp.getProxy();
-    assertEquals("AutoRefreshRMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy2, actualProxy2.proxy);
+    assertEquals(
+       mockProxy2, actualProxy2.proxy, "AutoRefreshRMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // check the proxy is different with the one we created before.
-    assertNotEquals("AutoRefreshRMFailoverProxyProvider " +
-        "shouldn't generate same proxy after failover",
-        actualProxy1.proxy, actualProxy2.proxy);
+    assertNotEquals(
+       actualProxy1.proxy, actualProxy2.proxy, "AutoRefreshRMFailoverProxyProvider " +
+        "shouldn't generate same proxy after failover");
 
     // verify that mockRMProxy.getProxy() has been one with each address
     verify(mockRMProxy, times(1))
@@ -293,9 +293,9 @@ public class TestRMFailoverProxyProvider {
     FailoverProxyProvider.ProxyInfo<Proxy> actualProxy3 = fpp.getProxy();
 
     // check the proxy is the same as the one we created before.
-    assertEquals("ConfiguredRMFailoverProxyProvider " +
-        "doesn't generate expected proxy after failover",
-        mockProxy1, actualProxy3.proxy);
+    assertEquals(
+       mockProxy1, actualProxy3.proxy, "ConfiguredRMFailoverProxyProvider " +
+        "doesn't generate expected proxy after failover");
 
     // verify that mockRMProxy.getProxy() is still only been invoked thrice
     verify(mockRMProxy, times(1))

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestResourceManagerAdministrationProtocolPBClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestResourceManagerAdministrationProtocolPBClientImpl.java
@@ -47,14 +47,14 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.RefreshUserToGroupsMapp
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceResponse;
 import org.apache.hadoop.yarn.server.resourcemanager.ResourceManager;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test ResourceManagerAdministrationProtocolPBClientImpl. Test a methods and the proxy without  logic.
@@ -72,7 +72,7 @@ public class TestResourceManagerAdministrationProtocolPBClientImpl {
    * Start resource manager server
    */
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpResourceManager() throws IOException,
           InterruptedException {
     Configuration.addDefaultResource("config-with-security.xml");
@@ -104,7 +104,7 @@ public class TestResourceManagerAdministrationProtocolPBClientImpl {
     }.start();
 
     boolean rmStarted = rmStartedSignal.await(60000L, TimeUnit.MILLISECONDS);
-    Assert.assertTrue("ResourceManager failed to start up.", rmStarted);
+    Assertions.assertTrue(rmStarted, "ResourceManager failed to start up.");
 
     LOG.info("ResourceManager RMAdmin address: {}.",
             configuration.get(YarnConfiguration.RM_ADMIN_ADDRESS));
@@ -197,7 +197,7 @@ public class TestResourceManagerAdministrationProtocolPBClientImpl {
    * Stop server
    */
 
-  @AfterClass
+  @AfterAll
   public static void tearDownResourceManager() throws InterruptedException {
     if (resourceManager != null) {
       LOG.info("Stopping ResourceManager...");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestResourceTrackerOnHA.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestResourceTrackerOnHA.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -33,10 +33,10 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.NodeHeartbeatRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.RegisterNodeManagerRequest;
 import org.apache.hadoop.yarn.server.api.records.NodeStatus;
 import org.apache.hadoop.yarn.util.YarnVersionInfo;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.Timeout;
 
 public class TestResourceTrackerOnHA extends ProtocolHATestBase {
@@ -46,13 +46,13 @@ public class TestResourceTrackerOnHA extends ProtocolHATestBase {
   @Rule
   public Timeout timeout = new Timeout(180, TimeUnit.SECONDS);
 
-  @Before
+  @BeforeEach
   public void initiate() throws Exception {
     startHACluster(0, false, true, false);
     this.resourceTracker = getRMClient();
   }
 
-  @After
+  @AfterEach
   public void shutDown() {
     if(this.resourceTracker != null) {
       RPC.stopProxy(this.resourceTracker);
@@ -69,7 +69,7 @@ public class TestResourceTrackerOnHA extends ProtocolHATestBase {
         RegisterNodeManagerRequest.newInstance(nodeId, 0, resource,
             YarnVersionInfo.getVersion(), null, null);
     resourceTracker.registerNodeManager(request);
-    Assert.assertTrue(waitForNodeManagerToConnect(200, nodeId));
+    Assertions.assertTrue(waitForNodeManagerToConnect(200, nodeId));
 
     // restart the failover thread, and make sure nodeHeartbeat works
     failoverThread = createAndStartFailoverThread();

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestYarnApiClasses.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/TestYarnApiClasses.java
@@ -28,9 +28,9 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestYarnApiClasses {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/async/impl/TestNMClientAsync.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/async/impl/TestNMClientAsync.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.service.ServiceOperations;
@@ -60,8 +60,9 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.factories.RecordFactory;
 import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.ipc.RPCUtil;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestNMClientAsync {
@@ -89,12 +90,13 @@ public class TestNMClientAsync {
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     ServiceOperations.stop(asyncClient);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testNMClientAsync() throws Exception {
     Configuration conf = new Configuration();
     conf.setInt(YarnConfiguration.NM_CLIENT_ASYNC_THREAD_POOL_MAX_SIZE, 10);
@@ -105,8 +107,8 @@ public class TestNMClientAsync {
 
     asyncClient = new MockNMClientAsync1(expectedSuccess, expectedFailure);
     asyncClient.init(conf);
-    Assert.assertEquals("The max thread pool size is not correctly set",
-        10, asyncClient.maxThreadPoolSize);
+    Assertions.assertEquals(
+       10, asyncClient.maxThreadPoolSize, "The max thread pool size is not correctly set");
     asyncClient.start();
 
 
@@ -149,25 +151,25 @@ public class TestNMClientAsync {
             .errorMsgs) {
       System.out.println(errorMsg);
     }
-    Assert.assertEquals("Error occurs in CallbackHandler", 0,
-        ((TestCallbackHandler1) asyncClient.getCallbackHandler())
-            .errorMsgs.size());
+    Assertions.assertEquals(0
+,         ((TestCallbackHandler1) asyncClient.getCallbackHandler())
+            .errorMsgs.size(), "Error occurs in CallbackHandler");
     for (String errorMsg : ((MockNMClientAsync1) asyncClient).errorMsgs) {
       System.out.println(errorMsg);
     }
-    Assert.assertEquals("Error occurs in ContainerEventProcessor", 0,
-        ((MockNMClientAsync1) asyncClient).errorMsgs.size());
+    Assertions.assertEquals(0
+,         ((MockNMClientAsync1) asyncClient).errorMsgs.size(), "Error occurs in ContainerEventProcessor");
     // When the callback functions are all executed, the event processor threads
     // may still not terminate and the containers may still not removed.
     while (asyncClient.containers.size() > 0) {
       Thread.sleep(10);
     }
     asyncClient.stop();
-    Assert.assertFalse(
-        "The thread of Container Management Event Dispatcher is still alive",
-        asyncClient.eventDispatcherThread.isAlive());
-    Assert.assertTrue("The thread pool is not shut down",
-        asyncClient.threadPool.isShutdown());
+    Assertions.assertFalse(
+    
+       asyncClient.eventDispatcherThread.isAlive(), "The thread of Container Management Event Dispatcher is still alive");
+    Assertions.assertTrue(
+       asyncClient.threadPool.isShutdown(), "The thread pool is not shut down");
   }
 
   private class MockNMClientAsync1 extends NMClientAsyncImpl {
@@ -697,7 +699,7 @@ public class TestNMClientAsync {
 
     private void assertAtomicIntegerArray(AtomicIntegerArray array) {
       for (int i = 0; i < array.length(); ++i) {
-        Assert.assertEquals(1, array.get(i));
+        Assertions.assertEquals(1, array.get(i));
       }
     }
   }
@@ -764,7 +766,8 @@ public class TestNMClientAsync {
     return client;
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testOutOfOrder() throws Exception {
     CyclicBarrier barrierA = new CyclicBarrier(2);
     CyclicBarrier barrierB = new CyclicBarrier(2);
@@ -790,9 +793,9 @@ public class TestNMClientAsync {
     asyncClient.stopContainerAsync(container.getId(), container.getNodeId());
     barrierC.await();
 
-    Assert.assertFalse("Starting and stopping should be out of order",
-        ((TestCallbackHandler2) asyncClient.getCallbackHandler())
-            .exceptionOccurred.get());
+    Assertions.assertFalse(
+       ((TestCallbackHandler2) asyncClient.getCallbackHandler())
+            .exceptionOccurred.get(), "Starting and stopping should be out of order");
   }
 
   private class MockNMClientAsync2 extends NMClientAsyncImpl {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/BaseAMRMClientTest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/BaseAMRMClientTest.java
@@ -43,8 +43,8 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptS
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -53,8 +53,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Base class for testing AMRMClient.
@@ -83,7 +83,7 @@ public class BaseAMRMClientTest {
   protected String[] nodes;
   protected String[] racks;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new YarnConfiguration();
     createClusterAndStartApplication(conf);
@@ -120,12 +120,12 @@ public class BaseAMRMClientTest {
     yarnClient.start();
 
     // get node info
-    assertTrue("All node managers did not connect to the RM within the "
-            + "allotted 5-second timeout",
-        yarnCluster.waitForNodeManagersToConnect(5000L));
+    assertTrue(
+       yarnCluster.waitForNodeManagersToConnect(5000L), "All node managers did not connect to the RM within the "
+            + "allotted 5-second timeout");
     nodeReports = yarnClient.getNodeReports(NodeState.RUNNING);
-    assertEquals("Not all node managers were reported running",
-        nodeCount, nodeReports.size());
+    assertEquals(
+       nodeCount, nodeReports.size(), "Not all node managers were reported running");
 
     priority = Priority.newInstance(1);
     priority2 = Priority.newInstance(2);
@@ -194,7 +194,7 @@ public class BaseAMRMClientTest {
         ClientRMProxy.getAMRMTokenService(conf));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws YarnException, IOException {
     if (yarnClient != null) {
       yarnClient.killApplication(attemptId.getApplicationId());

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAHSClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAHSClient.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.ApplicationHistoryProtocol;
@@ -58,7 +58,8 @@ import org.apache.hadoop.yarn.api.records.YarnApplicationAttemptState;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.AHSClient;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestAHSClient {
 
@@ -71,7 +72,8 @@ public class TestAHSClient {
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplications() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -82,14 +84,15 @@ public class TestAHSClient {
         ((MockAHSClient) client).getReports();
 
     List<ApplicationReport> reports = client.getApplications();
-    Assert.assertEquals(reports, expectedReports);
+    Assertions.assertEquals(reports, expectedReports);
 
     reports = client.getApplications();
     assertThat(reports).hasSize(4);
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplicationReport() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -100,15 +103,16 @@ public class TestAHSClient {
         ((MockAHSClient) client).getReports();
     ApplicationId applicationId = ApplicationId.newInstance(1234, 5);
     ApplicationReport report = client.getApplicationReport(applicationId);
-    Assert.assertEquals(report, expectedReports.get(0));
-    Assert.assertEquals(report.getApplicationId().toString(), expectedReports
+    Assertions.assertEquals(report, expectedReports.get(0));
+    Assertions.assertEquals(report.getApplicationId().toString(), expectedReports
       .get(0).getApplicationId().toString());
-    Assert.assertEquals(report.getSubmitTime(), expectedReports.get(0)
+    Assertions.assertEquals(report.getSubmitTime(), expectedReports.get(0)
       .getSubmitTime());
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplicationAttempts() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -118,15 +122,16 @@ public class TestAHSClient {
     ApplicationId applicationId = ApplicationId.newInstance(1234, 5);
     List<ApplicationAttemptReport> reports =
         client.getApplicationAttempts(applicationId);
-    Assert.assertNotNull(reports);
-    Assert.assertEquals(reports.get(0).getApplicationAttemptId(),
+    Assertions.assertNotNull(reports);
+    Assertions.assertEquals(reports.get(0).getApplicationAttemptId(),
       ApplicationAttemptId.newInstance(applicationId, 1));
-    Assert.assertEquals(reports.get(1).getApplicationAttemptId(),
+    Assertions.assertEquals(reports.get(1).getApplicationAttemptId(),
       ApplicationAttemptId.newInstance(applicationId, 2));
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplicationAttempt() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -141,13 +146,14 @@ public class TestAHSClient {
         ApplicationAttemptId.newInstance(applicationId, 1);
     ApplicationAttemptReport report =
         client.getApplicationAttemptReport(appAttemptId);
-    Assert.assertNotNull(report);
-    Assert.assertEquals(report.getApplicationAttemptId().toString(),
+    Assertions.assertNotNull(report);
+    Assertions.assertEquals(report.getApplicationAttemptId().toString(),
       expectedReports.get(0).getCurrentApplicationAttemptId().toString());
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetContainers() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -158,15 +164,16 @@ public class TestAHSClient {
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(applicationId, 1);
     List<ContainerReport> reports = client.getContainers(appAttemptId);
-    Assert.assertNotNull(reports);
-    Assert.assertEquals(reports.get(0).getContainerId(),
+    Assertions.assertNotNull(reports);
+    Assertions.assertEquals(reports.get(0).getContainerId(),
       (ContainerId.newContainerId(appAttemptId, 1)));
-    Assert.assertEquals(reports.get(1).getContainerId(),
+    Assertions.assertEquals(reports.get(1).getContainerId(),
       (ContainerId.newContainerId(appAttemptId, 2)));
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetContainerReport() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final AHSClient client = new MockAHSClient();
@@ -181,8 +188,8 @@ public class TestAHSClient {
         ApplicationAttemptId.newInstance(applicationId, 1);
     ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
     ContainerReport report = client.getContainerReport(containerId);
-    Assert.assertNotNull(report);
-    Assert.assertEquals(report.getContainerId().toString(), (ContainerId
+    Assertions.assertNotNull(report);
+    Assertions.assertEquals(report.getContainerId().toString(), (ContainerId
       .newContainerId(expectedReports.get(0).getCurrentApplicationAttemptId(), 1))
       .toString());
     client.stop();
@@ -240,9 +247,9 @@ public class TestAHSClient {
           .thenReturn(mockContainerResponse);
 
       } catch (YarnException e) {
-        Assert.fail("Exception is not expected.");
+        Assertions.fail("Exception is not expected.");
       } catch (IOException e) {
-        Assert.fail("Exception is not expected.");
+        Assertions.fail("Exception is not expected.");
       }
     }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAHSv2ClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAHSv2ClientImpl.java
@@ -40,9 +40,9 @@ import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.server.metrics.AppAttemptMetricsConstants;
 import org.apache.hadoop.yarn.server.metrics.ApplicationMetricsConstants;
 import org.apache.hadoop.yarn.server.metrics.ContainerMetricsConstants;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -57,7 +57,7 @@ public class TestAHSv2ClientImpl {
 
   private AHSv2ClientImpl client;
   private TimelineReaderClient spyTimelineReaderClient;
-  @Before
+  @BeforeEach
   public void setup() {
     Configuration conf = new YarnConfiguration();
     conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_ENABLED, true);
@@ -116,7 +116,7 @@ public class TestAHSv2ClientImpl {
     assertThat(report.getApplicationId()).isEqualTo(appId);
     assertThat(report.getAppNodeLabelExpression()).
         isEqualTo("test_node_label");
-    Assert.assertTrue(report.getApplicationTags().contains("Test_APP_TAGS_1"));
+    Assertions.assertTrue(report.getApplicationTags().contains("Test_APP_TAGS_1"));
     assertThat(report.getYarnApplicationState()).
         isEqualTo(YarnApplicationState.FINISHED);
   }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClient.java
@@ -19,11 +19,11 @@
 package org.apache.hadoop.yarn.client.api.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -77,9 +77,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedule
 import org.apache.hadoop.yarn.server.resourcemanager.security.AMRMTokenSecretManager;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
@@ -111,7 +112,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     });
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientNoMatchingRequests()
       throws IOException, YarnException {
     AMRMClient<ContainerRequest> amClient =  AMRMClient.createAMRMClient();
@@ -122,10 +124,11 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     Resource testCapability1 = Resource.newInstance(1024,  2);
     List<? extends Collection<ContainerRequest>> matches =
         amClient.getMatchingRequests(priority, node, testCapability1);
-    assertEquals("Expected no matching requests.", matches.size(), 0);
+    assertEquals(matches.size(), 0, "Expected no matching requests.");
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientMatchingFit() throws YarnException, IOException {
     AMRMClient<ContainerRequest> amClient = null;
     try {
@@ -266,7 +269,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
   /**
    * Test fit of both GUARANTEED and OPPORTUNISTIC containers.
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientMatchingFitExecType()
       throws YarnException, IOException {
     AMRMClient<ContainerRequest> amClient = null;
@@ -403,7 +407,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     assertEquals(matchSize, matches.get(0).size());
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientMatchingFitInferredRack()
       throws YarnException, IOException {
     AMRMClientImpl<ContainerRequest> amClient = null;
@@ -598,7 +603,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAllocationWithBlacklist() throws YarnException, IOException {
     AMRMClientImpl<ContainerRequest> amClient = null;
     try {
@@ -663,7 +669,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
   
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithBlacklist() throws YarnException, IOException {
     AMRMClientImpl<ContainerRequest> amClient = null;
     try {
@@ -737,17 +744,20 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     return allocatedContainerCount;
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClient() throws YarnException, IOException {
     initAMRMClientAndTest(false);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientAllocReqId() throws YarnException, IOException {
     initAMRMClientAndTest(true);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithSaslEncryption() throws Exception {
     // we have to create a new instance of MiniYARNCluster to avoid SASL qop
     // mismatches between client and server
@@ -768,7 +778,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
       //setting an instance NMTokenCache
       amClient.setNMTokenCache(new NMTokenCache());
       //asserting we are not using the singleton instance cache
-      Assert.assertNotSame(NMTokenCache.getSingleton(), 
+      Assertions.assertNotSame(NMTokenCache.getSingleton(), 
           amClient.getNMTokenCache());
 
       amClient.init(conf);
@@ -792,7 +802,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
   
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAskWithNodeLabels() {
     AMRMClientImpl<ContainerRequest> client =
         new AMRMClientImpl<ContainerRequest>();
@@ -824,7 +835,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
       if (ResourceRequest.ANY.equals(req.getResourceName())) {
         assertEquals("y", req.getNodeLabelExpression());
       } else {
-        Assert.assertNull(req.getNodeLabelExpression());
+        Assertions.assertNull(req.getNodeLabelExpression());
       }
     }
     // set container with nodes and racks with labels
@@ -835,7 +846,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
       if (ResourceRequest.ANY.equals(req.getResourceName())) {
         assertEquals("y", req.getNodeLabelExpression());
       } else {
-        Assert.assertNull(req.getNodeLabelExpression());
+        Assertions.assertNull(req.getNodeLabelExpression());
       }
     }
   }
@@ -850,7 +861,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     fail();
   }
   
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30)
   public void testAskWithInvalidNodeLabels() {
     AMRMClientImpl<ContainerRequest> client =
         new AMRMClientImpl<ContainerRequest>();
@@ -861,7 +873,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
             Priority.UNDEFINED, true, "x && y"));
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithContainerResourceChange()
       throws YarnException, IOException {
     // Fair scheduler does not support resource change
@@ -870,18 +883,18 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     try {
       // start am rm client
       amClient = AMRMClient.createAMRMClient();
-      Assert.assertNotNull(amClient);
+      Assertions.assertNotNull(amClient);
       // asserting we are using the singleton instance cache
-      Assert.assertSame(
+      Assertions.assertSame(
           NMTokenCache.getSingleton(), amClient.getNMTokenCache());
       amClient.init(conf);
       amClient.start();
       assertEquals(STATE.STARTED, amClient.getServiceState());
       // start am nm client
       NMClientImpl nmClient = (NMClientImpl) NMClient.createNMClient();
-      Assert.assertNotNull(nmClient);
+      Assertions.assertNotNull(nmClient);
       // asserting we are using the singleton instance cache
-      Assert.assertSame(
+      Assertions.assertSame(
           NMTokenCache.getSingleton(), nmClient.getNMTokenCache());
       nmClient.init(conf);
       nmClient.start();
@@ -1028,7 +1041,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
       }
     }
 
-    Assert.assertEquals("Container resource change update failed", 1, updateResponse.size());
+    Assertions.assertEquals(1, updateResponse.size(), "Container resource change update failed");
   }
 
   @Test
@@ -1042,7 +1055,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
 
     // start am nm client
     NMClientImpl nmClient = (NMClientImpl) NMClient.createNMClient();
-    Assert.assertNotNull(nmClient);
+    Assertions.assertNotNull(nmClient);
     nmClient.init(conf);
     nmClient.start();
     assertEquals(STATE.STARTED, nmClient.getServiceState());
@@ -1164,23 +1177,24 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithContainerPromotion()
       throws YarnException, IOException {
     AMRMClientImpl<AMRMClient.ContainerRequest> amClient =
         (AMRMClientImpl<AMRMClient.ContainerRequest>) AMRMClient
             .createAMRMClient();
     //asserting we are not using the singleton instance cache
-    Assert.assertSame(NMTokenCache.getSingleton(),
+    Assertions.assertSame(NMTokenCache.getSingleton(),
         amClient.getNMTokenCache());
     amClient.init(conf);
     amClient.start();
 
     // start am nm client
     NMClientImpl nmClient = (NMClientImpl) NMClient.createNMClient();
-    Assert.assertNotNull(nmClient);
+    Assertions.assertNotNull(nmClient);
     // asserting we are using the singleton instance cache
-    Assert.assertSame(
+    Assertions.assertSame(
         NMTokenCache.getSingleton(), nmClient.getNMTokenCache());
     nmClient.init(conf);
     nmClient.start();
@@ -1305,22 +1319,23 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     amClient.ask.clear();
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithContainerDemotion()
       throws YarnException, IOException {
     AMRMClientImpl<AMRMClient.ContainerRequest> amClient =
         (AMRMClientImpl<AMRMClient.ContainerRequest>) AMRMClient
             .createAMRMClient();
     //asserting we are not using the singleton instance cache
-    Assert.assertSame(NMTokenCache.getSingleton(),
+    Assertions.assertSame(NMTokenCache.getSingleton(),
         amClient.getNMTokenCache());
     amClient.init(conf);
     amClient.start();
 
     NMClientImpl nmClient = (NMClientImpl) NMClient.createNMClient();
-    Assert.assertNotNull(nmClient);
+    Assertions.assertNotNull(nmClient);
     // asserting we are using the singleton instance cache
-    Assert.assertSame(
+    Assertions.assertSame(
         NMTokenCache.getSingleton(), nmClient.getNMTokenCache());
     nmClient.init(conf);
     nmClient.start();
@@ -1777,7 +1792,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientOnAMRMTokenRollOver() throws YarnException,
       IOException {
     AMRMClient<ContainerRequest> amClient = null;
@@ -1797,7 +1813,7 @@ public class TestAMRMClient extends BaseAMRMClientTest{
 
       org.apache.hadoop.security.token.Token<AMRMTokenIdentifier> amrmToken_1 =
           getAMRMToken();
-      Assert.assertNotNull(amrmToken_1);
+      Assertions.assertNotNull(amrmToken_1);
       assertEquals(amrmToken_1.decodeIdentifier().getKeyId(),
         amrmTokenSecretManager.getMasterKey().getMasterKey().getKeyId());
 
@@ -1812,11 +1828,11 @@ public class TestAMRMClient extends BaseAMRMClientTest{
 
       org.apache.hadoop.security.token.Token<AMRMTokenIdentifier> amrmToken_2 =
           getAMRMToken();
-      Assert.assertNotNull(amrmToken_2);
+      Assertions.assertNotNull(amrmToken_2);
       assertEquals(amrmToken_2.decodeIdentifier().getKeyId(),
         amrmTokenSecretManager.getMasterKey().getMasterKey().getKeyId());
 
-      Assert.assertNotEquals(amrmToken_1, amrmToken_2);
+      Assertions.assertNotEquals(amrmToken_1, amrmToken_2);
 
       // can do the allocate call with latest AMRMToken
       AllocateResponse response = amClient.allocate(0.1f);
@@ -1924,7 +1940,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     return result;
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testGetMatchingFitWithProfiles() throws Exception {
     teardown();
     conf.setBoolean(YarnConfiguration.RM_RESOURCE_PROFILES_ENABLED, true);
@@ -2010,7 +2027,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testNoUpdateTrackingUrl()  {
     try {
       AMRMClientImpl<ContainerRequest> amClient = null;
@@ -2044,7 +2062,8 @@ public class TestAMRMClient extends BaseAMRMClientTest{
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateTrackingUrl() {
     try {
       AMRMClientImpl<ContainerRequest> amClient = null;

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientContainerRequest.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientContainerRequest.java
@@ -18,7 +18,8 @@
 
 package org.apache.hadoop.yarn.client.api.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +35,7 @@ import org.apache.hadoop.yarn.api.records.ResourceRequest;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 import org.apache.hadoop.yarn.client.api.InvalidContainerRequestException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAMRMClientContainerRequest {
 
@@ -169,25 +170,26 @@ public class TestAMRMClientContainerRequest {
     client.addContainerRequest(bothLevelRequest2);
   }
   
-  @Test (expected = InvalidContainerRequestException.class)
+  @Test
   public void testDifferentLocalityRelaxationSamePriority() {
-    AMRMClientImpl<ContainerRequest> client =
-        new AMRMClientImpl<ContainerRequest>();
-    Configuration conf = new Configuration();
-    conf.setClass(
-        CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
-        MyResolver.class, DNSToSwitchMapping.class);
-    client.init(conf);
-    
-    Resource capability = Resource.newInstance(1024, 1);
-    ContainerRequest request1 =
-        new ContainerRequest(capability, new String[] {"host1", "host2"},
-            null, Priority.newInstance(1), false);
-    client.addContainerRequest(request1);
-    ContainerRequest request2 =
-        new ContainerRequest(capability, new String[] {"host3"},
-            null, Priority.newInstance(1), true);
-    client.addContainerRequest(request2);
+    assertThrows(InvalidContainerRequestException.class, ()->{
+      AMRMClientImpl<ContainerRequest> client = new AMRMClientImpl<ContainerRequest>();
+      Configuration conf = new Configuration();
+      conf.setClass(
+          CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+          MyResolver.class, DNSToSwitchMapping.class);
+      client.init(conf);
+
+      Resource capability = Resource.newInstance(1024, 1);
+      ContainerRequest request1 =
+          new ContainerRequest(capability, new String[] {"host1", "host2"},
+          null, Priority.newInstance(1), false);
+      client.addContainerRequest(request1);
+      ContainerRequest request2 =
+          new ContainerRequest(capability, new String[] {"host3"},
+          null, Priority.newInstance(1), true);
+      client.addContainerRequest(request2);
+    });
   }
   
   @Test
@@ -229,25 +231,26 @@ public class TestAMRMClientContainerRequest {
 
   }
   
-  @Test (expected = InvalidContainerRequestException.class)
+  @Test
   public void testLocalityRelaxationDifferentLevels() {
-    AMRMClientImpl<ContainerRequest> client =
-        new AMRMClientImpl<ContainerRequest>();
-    Configuration conf = new Configuration();
-    conf.setClass(
-        CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
-        MyResolver.class, DNSToSwitchMapping.class);
-    client.init(conf);
-    
-    Resource capability = Resource.newInstance(1024, 1);
-    ContainerRequest request1 =
-        new ContainerRequest(capability, new String[] {"host1", "host2"},
-            null, Priority.newInstance(1), false);
-    client.addContainerRequest(request1);
-    ContainerRequest request2 =
-        new ContainerRequest(capability, null,
-            new String[] {"rack1"}, Priority.newInstance(1), true);
-    client.addContainerRequest(request2);
+    assertThrows(InvalidContainerRequestException.class, () -> {
+      AMRMClientImpl<ContainerRequest> client =
+          new AMRMClientImpl<ContainerRequest>();
+      Configuration conf = new Configuration();
+      conf.setClass(
+          CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY,
+          MyResolver.class, DNSToSwitchMapping.class);
+      client.init(conf);
+
+      Resource capability = Resource.newInstance(1024, 1);
+      ContainerRequest request1 =
+          new ContainerRequest(capability, new String[]{"host1", "host2"},
+          null, Priority.newInstance(1), false);
+      client.addContainerRequest(request1);
+      ContainerRequest request2 = new ContainerRequest(capability, null,
+          new String[]{"rack1"}, Priority.newInstance(1), true);
+      client.addContainerRequest(request2);
+    });
   }
   
   private static class MyResolver implements DNSToSwitchMapping {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientOnRMRestart.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientOnRMRestart.java
@@ -72,17 +72,18 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.SchedulerEv
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fifo.FifoScheduler;
 import org.apache.hadoop.yarn.server.resourcemanager.security.AMRMTokenSecretManager;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestAMRMClientOnRMRestart {
   static Configuration conf = new Configuration();
   static final int rolling_interval_sec = 13;
   static final long am_expire_ms = 4000;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf.setBoolean(
         CommonConfigurationKeys.HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, false);
@@ -97,7 +98,7 @@ public class TestAMRMClientOnRMRestart {
     conf.set(YarnConfiguration.RM_SCHEDULER_ADDRESS, "0.0.0.0:0");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     conf.setBoolean(
         CommonConfigurationKeys.HADOOP_SECURITY_TOKEN_SERVICE_USE_IP, true);
@@ -116,7 +117,8 @@ public class TestAMRMClientOnRMRestart {
   // Verify AM can recover increase request after resync
   // Step-5 : Allocater after resync command & new containerRequest(cRequest6)
   // Step-6 : RM allocates containers i.e cRequest4,cRequest5 and cRequest6
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientResendsRequestsOnRMRestart() throws Exception {
 
     UserGroupInformation.setLoginUser(null);
@@ -175,8 +177,8 @@ public class TestAMRMClientOnRMRestart {
 
     AllocateResponse allocateResponse = amClient.allocate(0.1f);
     rm1.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, allocateResponse
-        .getAllocatedContainers().size());
+    Assertions.assertEquals(0, allocateResponse
+        .getAllocatedContainers().size(), "No of assignments must be 0");
 
     // Why 4 ask, why not 3 ask even h2 is blacklisted?
     // On blacklisting host,applicationmaster has to remove ask request from
@@ -192,8 +194,8 @@ public class TestAMRMClientOnRMRestart {
     allocateResponse = amClient.allocate(0.2f);
     rm1.drainEvents();
     // 3 containers are allocated i.e for cRequest1, cRequest2 and cRequest3.
-    Assert.assertEquals("No of assignments must be 0", 3, allocateResponse
-        .getAllocatedContainers().size());
+    Assertions.assertEquals(3, allocateResponse
+        .getAllocatedContainers().size(), "No of assignments must be 0");
     assertAsksAndReleases(0, 0, rm1);
     assertBlacklistAdditionsAndRemovals(0, 0, rm1);
 
@@ -206,8 +208,8 @@ public class TestAMRMClientOnRMRestart {
 
     allocateResponse = amClient.allocate(0.2f);
     rm1.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, allocateResponse
-        .getAllocatedContainers().size());
+    Assertions.assertEquals(0, allocateResponse
+        .getAllocatedContainers().size(), "No of assignments must be 0");
     assertAsksAndReleases(4, 0, rm1);
     assertBlacklistAdditionsAndRemovals(0, 0, rm1);
 
@@ -241,8 +243,8 @@ public class TestAMRMClientOnRMRestart {
 
     allocateResponse = amClient.allocate(0.3f);
     rm1.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, allocateResponse
-        .getAllocatedContainers().size());
+    Assertions.assertEquals(0, allocateResponse
+        .getAllocatedContainers().size(), "No of assignments must be 0");
     assertAsksAndReleases(3, pendingRelease, rm1);
     // Verify there is one increase and zero decrease
     assertChanges(1, 0, rm1);
@@ -259,7 +261,7 @@ public class TestAMRMClientOnRMRestart {
 
     // NM should be rebooted on heartbeat, even first heartbeat for nm2
     NodeHeartbeatResponse hbResponse = nm1.nodeHeartbeat(true);
-    Assert.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
+    Assertions.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
 
     // new NM to represent NM re-register
     nm1 = new MockNM("h1:1234", 10240, rm2.getResourceTrackerService());
@@ -311,8 +313,8 @@ public class TestAMRMClientOnRMRestart {
     // Step-5 : Allocater after resync command
     allocateResponse = amClient.allocate(0.5f);
     rm2.drainEvents();
-    Assert.assertEquals("No of assignments must be 0", 0, allocateResponse
-        .getAllocatedContainers().size());
+    Assertions.assertEquals(0, allocateResponse
+        .getAllocatedContainers().size(), "No of assignments must be 0");
 
     assertAsksAndReleases(5, 0, rm2);
     // Verify there is no increase or decrease requests any more
@@ -335,8 +337,8 @@ public class TestAMRMClientOnRMRestart {
     }
 
     // Step-6 : RM allocates containers i.e cRequest4,cRequest5 and cRequest6
-    Assert.assertEquals("Number of container should be 3", 3,
-        noAssignedContainer);
+    Assertions.assertEquals(3
+,         noAssignedContainer, "Number of container should be 3");
 
     amClient.stop();
     rm1.stop();
@@ -346,7 +348,8 @@ public class TestAMRMClientOnRMRestart {
   // Test verify for
   // 1. AM try to unregister without registering
   // 2. AM register to RM, and try to unregister immediately after RM restart
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientForUnregisterAMOnRMRestart() throws Exception {
 
     MemoryRMStateStore memStore = new MemoryRMStateStore();
@@ -391,7 +394,7 @@ public class TestAMRMClientOnRMRestart {
 
     // NM should be rebooted on heartbeat, even first heartbeat for nm2
     NodeHeartbeatResponse hbResponse = nm1.nodeHeartbeat(true);
-    Assert.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
+    Assertions.assertEquals(NodeAction.RESYNC, hbResponse.getNodeAction());
 
     // new NM to represent NM re-register
     nm1 = new MockNM("h1:1234", 10240, rm2.getResourceTrackerService());
@@ -420,7 +423,8 @@ public class TestAMRMClientOnRMRestart {
 
   // Test verify for AM issued with rolled-over AMRMToken
   // is still able to communicate with restarted RM.
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAMRMClientOnAMRMTokenRollOverOnRMRestart() throws Exception {
     conf.setLong(
       YarnConfiguration.RM_AMRM_TOKEN_MASTER_KEY_ROLLING_INTERVAL_SECS,
@@ -471,7 +475,7 @@ public class TestAMRMClientOnRMRestart {
         // DO NOTHING
       }
     }
-    Assert.assertTrue(amrmTokenSecretManagerForRM1.getMasterKey()
+    Assertions.assertTrue(amrmTokenSecretManagerForRM1.getMasterKey()
       .getMasterKey().getKeyId() != token.decodeIdentifier().getKeyId());
 
     amClient.allocate(0.1f);
@@ -492,9 +496,9 @@ public class TestAMRMClientOnRMRestart {
       }
       Thread.sleep(500);
     }
-    Assert
+    Assertions
       .assertTrue(amrmTokenSecretManagerForRM1.getNextMasterKeyData() == null);
-    Assert.assertTrue(amrmTokenSecretManagerForRM1.getCurrnetMasterKeyData()
+    Assertions.assertTrue(amrmTokenSecretManagerForRM1.getCurrnetMasterKeyData()
       .getMasterKey().getKeyId() == newToken.decodeIdentifier().getKeyId());
 
     // start 2nd RM
@@ -505,9 +509,9 @@ public class TestAMRMClientOnRMRestart {
 
     AMRMTokenSecretManager amrmTokenSecretManagerForRM2 =
         rm2.getRMContext().getAMRMTokenSecretManager();
-    Assert.assertTrue(amrmTokenSecretManagerForRM2.getCurrnetMasterKeyData()
+    Assertions.assertTrue(amrmTokenSecretManagerForRM2.getCurrnetMasterKeyData()
       .getMasterKey().getKeyId() == newToken.decodeIdentifier().getKeyId());
-    Assert
+    Assertions
       .assertTrue(amrmTokenSecretManagerForRM2.getNextMasterKeyData() == null);
 
     try {
@@ -524,10 +528,10 @@ public class TestAMRMClientOnRMRestart {
             rm2.getApplicationMasterService().getBindAddress(), conf);
         }
       }).allocate(Records.newRecord(AllocateRequest.class));
-      Assert.fail("The old Token should not work");
+      Assertions.fail("The old Token should not work");
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof InvalidToken);
-      Assert.assertTrue(ex.getMessage().contains(
+      Assertions.assertTrue(ex instanceof InvalidToken);
+      Assertions.assertTrue(ex.getMessage().contains(
         "Invalid AMRMToken from "
             + token.decodeIdentifier().getApplicationAttemptId()));
     }
@@ -665,24 +669,24 @@ public class TestAMRMClientOnRMRestart {
 
   private static void assertBlacklistAdditionsAndRemovals(
       int expectedAdditions, int expectedRemovals, MyResourceManager rm) {
-    Assert.assertEquals(expectedAdditions,
+    Assertions.assertEquals(expectedAdditions,
         rm.getMyFifoScheduler().lastBlacklistAdditions.size());
-    Assert.assertEquals(expectedRemovals,
+    Assertions.assertEquals(expectedRemovals,
         rm.getMyFifoScheduler().lastBlacklistRemovals.size());
   }
 
   private static void assertAsksAndReleases(int expectedAsk,
       int expectedRelease, MyResourceManager rm) {
-    Assert.assertEquals(expectedAsk, rm.getMyFifoScheduler().lastAsk.size());
-    Assert.assertEquals(expectedRelease,
+    Assertions.assertEquals(expectedAsk, rm.getMyFifoScheduler().lastAsk.size());
+    Assertions.assertEquals(expectedRelease,
         rm.getMyFifoScheduler().lastRelease.size());
   }
 
   private static void assertChanges(
       int expectedIncrease, int expectedDecrease, MyResourceManager rm) {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedIncrease, rm.getMyFifoScheduler().lastIncrease.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedDecrease, rm.getMyFifoScheduler().lastDecrease.size());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientPlacementConstraints.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMClientPlacementConstraints.java
@@ -36,9 +36,10 @@ import org.apache.hadoop.yarn.client.api.NMTokenCache;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.impl.AMRMClientAsyncImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,7 +64,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
   private List<RejectedSchedulingRequest> rejectedSchedulingRequests = null;
   private Map<Set<String>, PlacementConstraint> pcMapping = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new YarnConfiguration();
     allocatedContainers = new ArrayList<>();
@@ -77,7 +78,8 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
             PlacementConstraints.targetNotIn(NODE, allocationTag("bar"))));
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithPlacementConstraintsByPlacementProcessor()
       throws Exception {
     // we have to create a new instance of MiniYARNCluster to avoid SASL qop
@@ -92,7 +94,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
         AMRMClient.<AMRMClient.ContainerRequest>createAMRMClient();
     amClient.setNMTokenCache(new NMTokenCache());
     //asserting we are not using the singleton instance cache
-    Assert.assertNotSame(NMTokenCache.getSingleton(),
+    Assertions.assertNotSame(NMTokenCache.getSingleton(),
         amClient.getNMTokenCache());
     AMRMClientAsync asyncClient = new AMRMClientAsyncImpl<>(amClient,
         1000, new TestCallbackHandler());
@@ -120,7 +122,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     waitForContainerAllocation(allocatedContainers,
         rejectedSchedulingRequests, 6, 2);
 
-    Assert.assertEquals(6, allocatedContainers.size());
+    Assertions.assertEquals(6, allocatedContainers.size());
     Map<NodeId, List<Container>> containersPerNode =
         allocatedContainers.stream().collect(
             Collectors.groupingBy(Container::getNodeId));
@@ -128,19 +130,19 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     Map<Set<String>, List<SchedulingRequest>> outstandingSchedRequests =
         ((AMRMClientImpl)amClient).getOutstandingSchedRequests();
     // Check the outstanding SchedulingRequests
-    Assert.assertEquals(2, outstandingSchedRequests.size());
-    Assert.assertEquals(1, outstandingSchedRequests.get(
+    Assertions.assertEquals(2, outstandingSchedRequests.size());
+    Assertions.assertEquals(1, outstandingSchedRequests.get(
         new HashSet<>(Collections.singletonList("foo"))).size());
-    Assert.assertEquals(1, outstandingSchedRequests.get(
+    Assertions.assertEquals(1, outstandingSchedRequests.get(
         new HashSet<>(Collections.singletonList("bar"))).size());
 
     // Ensure 2 containers allocated per node.
     // Each node should have a "foo" and a "bar" container.
-    Assert.assertEquals(3, containersPerNode.entrySet().size());
+    Assertions.assertEquals(3, containersPerNode.entrySet().size());
     HashSet<String> srcTags = new HashSet<>(Arrays.asList("foo", "bar"));
     containersPerNode.entrySet().forEach(
         x ->
-          Assert.assertEquals(
+          Assertions.assertEquals(
               srcTags,
               x.getValue()
                   .stream()
@@ -149,8 +151,8 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     );
 
     // Ensure 2 rejected requests - 1 of "foo" and 1 of "bar"
-    Assert.assertEquals(2, rejectedSchedulingRequests.size());
-    Assert.assertEquals(srcTags,
+    Assertions.assertEquals(2, rejectedSchedulingRequests.size());
+    Assertions.assertEquals(srcTags,
         rejectedSchedulingRequests
             .stream()
             .map(x -> x.getRequest().getAllocationTags().iterator().next())
@@ -159,7 +161,8 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     asyncClient.stop();
   }
 
-  @Test(timeout=60000)
+  @Test
+  @Timeout(value = 60)
   public void testAMRMClientWithPlacementConstraintsByScheduler()
       throws Exception {
     // we have to create a new instance of MiniYARNCluster to avoid SASL qop
@@ -174,7 +177,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
         AMRMClient.<AMRMClient.ContainerRequest>createAMRMClient();
     amClient.setNMTokenCache(new NMTokenCache());
     //asserting we are not using the singleton instance cache
-    Assert.assertNotSame(NMTokenCache.getSingleton(),
+    Assertions.assertNotSame(NMTokenCache.getSingleton(),
         amClient.getNMTokenCache());
     AMRMClientAsync asyncClient = new AMRMClientAsyncImpl<>(amClient,
         1000, new TestCallbackHandler());
@@ -204,7 +207,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     waitForContainerAllocation(allocatedContainers,
         rejectedSchedulingRequests, 7, 0);
 
-    Assert.assertEquals(7, allocatedContainers.size());
+    Assertions.assertEquals(7, allocatedContainers.size());
     Map<NodeId, List<Container>> containersPerNode =
         allocatedContainers.stream().collect(
             Collectors.groupingBy(Container::getNodeId));
@@ -212,20 +215,20 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     Map<Set<String>, List<SchedulingRequest>> outstandingSchedRequests =
         ((AMRMClientImpl)amClient).getOutstandingSchedRequests();
     // Check the outstanding SchedulingRequests
-    Assert.assertEquals(3, outstandingSchedRequests.size());
-    Assert.assertEquals(1, outstandingSchedRequests.get(
+    Assertions.assertEquals(3, outstandingSchedRequests.size());
+    Assertions.assertEquals(1, outstandingSchedRequests.get(
         new HashSet<>(Collections.singletonList("foo"))).size());
-    Assert.assertEquals(1, outstandingSchedRequests.get(
+    Assertions.assertEquals(1, outstandingSchedRequests.get(
         new HashSet<>(Collections.singletonList("bar"))).size());
-    Assert.assertEquals(0, outstandingSchedRequests.get(
+    Assertions.assertEquals(0, outstandingSchedRequests.get(
         new HashSet<String>()).size());
 
     // Each node should have a "foo" and a "bar" container.
-    Assert.assertEquals(3, containersPerNode.entrySet().size());
+    Assertions.assertEquals(3, containersPerNode.entrySet().size());
     HashSet<String> srcTags = new HashSet<>(Arrays.asList("foo", "bar"));
     containersPerNode.entrySet().forEach(
         x ->
-          Assert.assertEquals(
+          Assertions.assertEquals(
               srcTags,
               x.getValue()
                   .stream()
@@ -235,7 +238,7 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
     );
 
     // The rejected requests were not set by scheduler
-    Assert.assertEquals(0, rejectedSchedulingRequests.size());
+    Assertions.assertEquals(0, rejectedSchedulingRequests.size());
 
     asyncClient.stop();
   }
@@ -258,8 +261,8 @@ public class TestAMRMClientPlacementConstraints extends BaseAMRMClientTest {
         schedulingRequest(1, 1, 3, 1, 512, schedRequest)));
     Map<Set<String>, List<SchedulingRequest>> outstandingSchedRequests =
         ((AMRMClientImpl)amClient).getOutstandingSchedRequests();
-    Assert.assertEquals(1, outstandingSchedRequests.size());
-    Assert.assertEquals(3, outstandingSchedRequests
+    Assertions.assertEquals(1, outstandingSchedRequests.size());
+    Assertions.assertEquals(3, outstandingSchedRequests
         .get(new HashSet<String>()).size());
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMProxy.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestAMRMProxy.java
@@ -43,8 +43,9 @@ import org.apache.hadoop.yarn.server.MiniYARNCluster;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMAppState;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairSchedulerConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,8 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
    * This test validates register, allocate and finish of an application through
    * the AMRMPRoxy.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testAMRMProxyE2E() throws Exception {
     ApplicationMasterProtocol client;
 
@@ -96,18 +98,17 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
           client.registerApplicationMaster(RegisterApplicationMasterRequest
               .newInstance(NetUtils.getHostname(), 1024, ""));
 
-      Assert.assertNotNull(responseRegister);
-      Assert.assertNotNull(responseRegister.getQueue());
-      Assert.assertNotNull(responseRegister.getApplicationACLs());
-      Assert.assertNotNull(responseRegister.getClientToAMTokenMasterKey());
-      Assert
-          .assertNotNull(responseRegister.getContainersFromPreviousAttempts());
-      Assert.assertNotNull(responseRegister.getSchedulerResourceTypes());
-      Assert.assertNotNull(responseRegister.getMaximumResourceCapability());
+      Assertions.assertNotNull(responseRegister);
+      Assertions.assertNotNull(responseRegister.getQueue());
+      Assertions.assertNotNull(responseRegister.getApplicationACLs());
+      Assertions.assertNotNull(responseRegister.getClientToAMTokenMasterKey());
+      Assertions.assertNotNull(responseRegister.getContainersFromPreviousAttempts());
+      Assertions.assertNotNull(responseRegister.getSchedulerResourceTypes());
+      Assertions.assertNotNull(responseRegister.getMaximumResourceCapability());
 
       RMApp rmApp =
           cluster.getResourceManager().getRMContext().getRMApps().get(appId);
-      Assert.assertEquals(RMAppState.RUNNING, rmApp.getState());
+      Assertions.assertEquals(RMAppState.RUNNING, rmApp.getState());
 
       LOG.info("testAMRMProxyE2E - Allocate Resources Application Master");
 
@@ -115,8 +116,8 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
           createAllocateRequest(rmClient.getNodeReports(NodeState.RUNNING));
 
       AllocateResponse allocResponse = client.allocate(request);
-      Assert.assertNotNull(allocResponse);
-      Assert.assertEquals(0, allocResponse.getAllocatedContainers().size());
+      Assertions.assertNotNull(allocResponse);
+      Assertions.assertEquals(0, allocResponse.getAllocatedContainers().size());
 
       request.setAskList(new ArrayList<ResourceRequest>());
       request.setResponseId(request.getResponseId() + 1);
@@ -125,8 +126,8 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
 
       // RM should allocate container within 2 calls to allocate()
       allocResponse = client.allocate(request);
-      Assert.assertNotNull(allocResponse);
-      Assert.assertEquals(2, allocResponse.getAllocatedContainers().size());
+      Assertions.assertNotNull(allocResponse);
+      Assertions.assertEquals(2, allocResponse.getAllocatedContainers().size());
 
       LOG.info("testAMRMPRoxy - Finish Application Master");
 
@@ -134,10 +135,10 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
           client.finishApplicationMaster(FinishApplicationMasterRequest
               .newInstance(FinalApplicationStatus.SUCCEEDED, "success", null));
 
-      Assert.assertNotNull(responseFinish);
+      Assertions.assertNotNull(responseFinish);
 
       Thread.sleep(500);
-      Assert.assertNotEquals(RMAppState.FINISHED, rmApp.getState());
+      Assertions.assertNotEquals(RMAppState.FINISHED, rmApp.getState());
 
     }
   }
@@ -147,7 +148,8 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
    * that the received token from AMRMProxy is different from the previous one
    * within 5 requests.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testAMRMProxyTokenRenewal() throws Exception {
     ApplicationMasterProtocol client;
 
@@ -207,7 +209,7 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
 
       }
 
-      Assert.assertFalse(response.getAMRMToken().equals(lastToken));
+      Assertions.assertFalse(response.getAMRMToken().equals(lastToken));
 
       LOG.info("testAMRMPRoxy - Finish Application Master");
 
@@ -221,7 +223,8 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
    * This test validates that an AM cannot register directly to the RM, with the
    * token provided by the AMRMProxy.
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120)
   public void testE2ETokenSwap() throws Exception {
     ApplicationMasterProtocol client;
 
@@ -246,9 +249,9 @@ public class TestAMRMProxy extends BaseAMRMProxyE2ETest {
       try {
         client.registerApplicationMaster(RegisterApplicationMasterRequest
             .newInstance(NetUtils.getHostname(), 1024, ""));
-        Assert.fail();
+        Assertions.fail();
       } catch (IOException e) {
-        Assert.assertTrue(
+        Assertions.assertTrue(
             e.getMessage().startsWith("Invalid AMRMToken from appattempt_"));
       }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestNMClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestNMClient.java
@@ -56,8 +56,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttempt;
 import org.apache.hadoop.yarn.server.resourcemanager.rmapp.attempt.RMAppAttemptState;
 import org.apache.hadoop.yarn.util.Records;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -69,11 +71,11 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestNMClient {
   private static final String IS_NOT_HANDLED_BY_THIS_NODEMANAGER =
@@ -197,7 +199,8 @@ public class TestNMClient {
     yarnCluster.stop();
   }
 
-  @Test (timeout = 180_000)
+  @Test
+  @Timeout(value = 180)
   public void testNMClientNoCleanupOnStop()
       throws YarnException, IOException, InterruptedException, TimeoutException {
     runTest(() -> {
@@ -208,7 +211,8 @@ public class TestNMClient {
     });
   }
 
-  @Test (timeout = 200_000)
+  @Test
+  @Timeout(value = 200)
   public void testNMClient()
       throws YarnException, IOException, InterruptedException, TimeoutException {
     runTest(() -> {
@@ -232,7 +236,7 @@ public class TestNMClient {
   }
 
   private void stopNmClient() {
-    assertNotNull("Null nmClient", nmClient);
+    assertNotNull(nmClient, "Null nmClient");
     // leave one unclosed
     assertEquals(1, nmClient.startedContainers.size());
     // default true
@@ -383,13 +387,13 @@ public class TestNMClient {
       // container status
       if (status.getState() == state) {
         assertEquals(container.getId(), status.getContainerId());
-        assertTrue(index + ": " + status.getDiagnostics(),
-                status.getDiagnostics().contains(diagnostics));
+        assertTrue(
+               status.getDiagnostics().contains(diagnostics), index + ": " + status.getDiagnostics());
 
-        assertTrue("Exit Statuses are supposed to be in: " + exitStatuses +
+        assertTrue(
+               exitStatuses.contains(status.getExitStatus()), "Exit Statuses are supposed to be in: " + exitStatuses +
                         ", but the actual exit status code is: " +
-                        status.getExitStatus(),
-                exitStatuses.contains(status.getExitStatus()));
+                        status.getExitStatus());
         break;
       }
     }
@@ -434,10 +438,10 @@ public class TestNMClient {
     nmClient.reInitializeContainer(container.getId(), clc, autoCommit);
   }
 
-  private void assertYarnException(ThrowingRunnable runnable, String text) {
+  private void assertYarnException(Executable runnable, String text) {
     YarnException e = assertThrows(YarnException.class, runnable);
-    assertTrue(String.format("The thrown exception is not expected cause it has text [%s]"
-        + ", what not contains text [%s]", e.getMessage(), text), e.getMessage().contains(text));
+    assertTrue(e.getMessage().contains(text), String.format("The thrown exception is not expected cause it has text [%s]"
+        + ", what not contains text [%s]", e.getMessage(), text));
   }
 
   private void sleep(int sleepTime) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestOpportunisticContainerAllocationE2E.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestOpportunisticContainerAllocationE2E.java
@@ -62,12 +62,13 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler
     .AbstractYarnScheduler;
 import org.apache.hadoop.yarn.server.utils.BuilderUtils;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -82,8 +83,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Class that tests the allocation of OPPORTUNISTIC containers through the
@@ -118,7 +119,7 @@ public class TestOpportunisticContainerAllocationE2E {
   private long allocMB;
   private int allocVCores;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     // start minicluster
     conf = new YarnConfiguration();
@@ -159,7 +160,7 @@ public class TestOpportunisticContainerAllocationE2E {
     racks = new String[]{rack};
   }
 
-  @Before
+  @BeforeEach
   public void startApp() throws Exception {
     // submit new app
     ApplicationSubmissionContext appContext =
@@ -223,7 +224,7 @@ public class TestOpportunisticContainerAllocationE2E {
     //setting an instance NMTokenCache
     amClient.setNMTokenCache(new NMTokenCache());
     //asserting we are not using the singleton instance cache
-    Assert.assertNotSame(NMTokenCache.getSingleton(),
+    Assertions.assertNotSame(NMTokenCache.getSingleton(),
         amClient.getNMTokenCache());
 
     amClient.init(conf);
@@ -232,7 +233,7 @@ public class TestOpportunisticContainerAllocationE2E {
     amClient.registerApplicationMaster("Host", 10000, "");
   }
 
-  @After
+  @AfterEach
   public void cancelApp() throws YarnException, IOException {
     try {
       amClient
@@ -248,7 +249,7 @@ public class TestOpportunisticContainerAllocationE2E {
     attemptId = null;
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (yarnClient != null &&
         yarnClient.getServiceState() == Service.STATE.STARTED) {
@@ -260,7 +261,8 @@ public class TestOpportunisticContainerAllocationE2E {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testPromotionFromAcquired() throws YarnException, IOException {
     // setup container request
     assertEquals(0, amClient.ask.size());
@@ -288,7 +290,7 @@ public class TestOpportunisticContainerAllocationE2E {
     int iterationsLeft = 50;
 
     amClient.getNMTokenCache().clearCache();
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         amClient.getNMTokenCache().numberOfTokensInCache());
     HashMap<String, Token> receivedNMTokens = new HashMap<>();
 
@@ -331,10 +333,10 @@ public class TestOpportunisticContainerAllocationE2E {
           c, UpdateContainerRequest.newInstance(c.getVersion(),
               c.getId(), ContainerUpdateType.PROMOTE_EXECUTION_TYPE,
               null, ExecutionType.OPPORTUNISTIC));
-      Assert.fail("Should throw Exception..");
+      Assertions.fail("Should throw Exception..");
     } catch (IllegalArgumentException e) {
       System.out.println("## " + e.getMessage());
-      Assert.assertTrue(e.getMessage().contains(
+      Assertions.assertTrue(e.getMessage().contains(
           "target should be GUARANTEED and original should be OPPORTUNISTIC"));
     }
 
@@ -385,7 +387,8 @@ public class TestOpportunisticContainerAllocationE2E {
     amClient.ask.clear();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testDemotionFromAcquired() throws YarnException, IOException {
     // setup container request
     assertEquals(0, amClient.ask.size());
@@ -409,7 +412,7 @@ public class TestOpportunisticContainerAllocationE2E {
     int iterationsLeft = 50;
 
     amClient.getNMTokenCache().clearCache();
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         amClient.getNMTokenCache().numberOfTokensInCache());
     HashMap<String, Token> receivedNMTokens = new HashMap<>();
 
@@ -452,10 +455,10 @@ public class TestOpportunisticContainerAllocationE2E {
           c, UpdateContainerRequest.newInstance(c.getVersion(),
               c.getId(), ContainerUpdateType.DEMOTE_EXECUTION_TYPE,
               null, ExecutionType.GUARANTEED));
-      Assert.fail("Should throw Exception..");
+      Assertions.fail("Should throw Exception..");
     } catch (IllegalArgumentException e) {
       System.out.println("## " + e.getMessage());
-      Assert.assertTrue(e.getMessage().contains(
+      Assertions.assertTrue(e.getMessage().contains(
           "target should be OPPORTUNISTIC and original should be GUARANTEED"));
     }
 
@@ -506,7 +509,8 @@ public class TestOpportunisticContainerAllocationE2E {
     amClient.ask.clear();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testMixedAllocationAndRelease() throws YarnException,
       IOException {
     // setup container request
@@ -594,7 +598,7 @@ public class TestOpportunisticContainerAllocationE2E {
     Set<ContainerId> releases = new TreeSet<>();
 
     amClient.getNMTokenCache().clearCache();
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         amClient.getNMTokenCache().numberOfTokensInCache());
     HashMap<String, Token> receivedNMTokens = new HashMap<>();
 
@@ -676,7 +680,8 @@ public class TestOpportunisticContainerAllocationE2E {
   /**
    * Tests allocation with requests comprising only opportunistic containers.
    */
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testOpportunisticAllocation() throws YarnException, IOException {
     // setup container request
     assertEquals(0, amClient.ask.size());
@@ -708,7 +713,7 @@ public class TestOpportunisticContainerAllocationE2E {
     Set<ContainerId> releases = new TreeSet<>();
 
     amClient.getNMTokenCache().clearCache();
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         amClient.getNMTokenCache().numberOfTokensInCache());
     HashMap<String, Token> receivedNMTokens = new HashMap<>();
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestSharedCacheClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestSharedCacheClientImpl.java
@@ -18,8 +18,7 @@
 
 package org.apache.hadoop.yarn.client.api.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,11 +39,11 @@ import org.apache.hadoop.yarn.api.protocolrecords.impl.pb.UseSharedCacheResource
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,7 @@ public class TestSharedCacheClientImpl {
   private static String inputChecksumSHA256 =
       "f29bc64a9d3732b4b9035125fdb3285f5b6455778edca72414671e0ca3b2e0de";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws IOException {
     localFs = FileSystem.getLocal(new Configuration());
     TEST_ROOT_DIR =
@@ -70,7 +69,7 @@ public class TestSharedCacheClientImpl {
             localFs.getWorkingDirectory());
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() {
     try {
       if (localFs != null) {
@@ -82,7 +81,7 @@ public class TestSharedCacheClientImpl {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     cProtocol = mock(ClientSCMProtocol.class);
     client = new SharedCacheClientImpl() {
@@ -100,7 +99,7 @@ public class TestSharedCacheClientImpl {
     client.start();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (client != null) {
       client.stop();
@@ -116,7 +115,7 @@ public class TestSharedCacheClientImpl {
     when(cProtocol.use(isA(UseSharedCacheResourceRequest.class))).thenReturn(
         response);
     URL newURL = client.use(mock(ApplicationId.class), "key");
-    assertNull("The path is not null!", newURL);
+    assertNull(newURL, "The path is not null!");
   }
 
   @Test
@@ -129,15 +128,17 @@ public class TestSharedCacheClientImpl {
     when(cProtocol.use(isA(UseSharedCacheResourceRequest.class))).thenReturn(
         response);
     URL newURL = client.use(mock(ApplicationId.class), "key");
-    assertEquals("The paths are not equal!", useUrl, newURL);
+    assertEquals(useUrl, newURL, "The paths are not equal!");
   }
 
-  @Test(expected = YarnException.class)
+  @Test
   public void testUseError() throws Exception {
-    String message = "Mock IOExcepiton!";
-    when(cProtocol.use(isA(UseSharedCacheResourceRequest.class))).thenThrow(
-        new IOException(message));
-    client.use(mock(ApplicationId.class), "key");
+    assertThrows(YarnException.class, ()->{
+      String message = "Mock IOExcepiton!";
+      when(cProtocol.use(isA(UseSharedCacheResourceRequest.class))).thenThrow(
+         new IOException(message));
+      client.use(mock(ApplicationId.class), "key");
+    });
   }
 
   @Test
@@ -148,12 +149,14 @@ public class TestSharedCacheClientImpl {
     client.release(mock(ApplicationId.class), "key");
   }
 
-  @Test(expected = YarnException.class)
+  @Test
   public void testReleaseError() throws Exception {
-    String message = "Mock IOExcepiton!";
-    when(cProtocol.release(isA(ReleaseSharedCacheResourceRequest.class)))
-        .thenThrow(new IOException(message));
-    client.release(mock(ApplicationId.class), "key");
+    assertThrows(YarnException.class, () -> {
+      String message = "Mock IOExcepiton!";
+      when(cProtocol.release(isA(ReleaseSharedCacheResourceRequest.class)))
+          .thenThrow(new IOException(message));
+      client.release(mock(ApplicationId.class), "key");
+    });
   }
 
   @Test
@@ -163,10 +166,12 @@ public class TestSharedCacheClientImpl {
     assertEquals(inputChecksumSHA256, client.getFileChecksum(file));
   }
 
-  @Test(expected = FileNotFoundException.class)
+  @Test
   public void testNonexistantFileChecksum() throws Exception {
-    Path file = new Path(TEST_ROOT_DIR, "non-existant-file");
-    client.getFileChecksum(file);
+    assertThrows(FileNotFoundException.class, () -> {
+      Path file = new Path(TEST_ROOT_DIR, "non-existant-file");
+      client.getFileChecksum(file);
+    });
   }
 
   private Path makeFile(String filename) throws Exception {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClient.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClient.java
@@ -77,9 +77,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmapp.RMApp;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler;
 import org.apache.hadoop.yarn.util.Records;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.event.Level;
 
@@ -97,6 +98,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -115,7 +117,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
 
   protected void configureFairScheduler(YarnConfiguration conf) {}
 
-  @Before
+  @BeforeEach
   public void setup() {
     QueueMetrics.clearQueueMetrics();
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -148,8 +150,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         new CreateTimelineClientErrorVerifier(1) {
           @Override
           public void verifyError(Throwable e) {
-            Assert.assertTrue(e instanceof NoClassDefFoundError);
-            Assert.assertTrue(e.getMessage() != null &&
+            Assertions.assertTrue(e instanceof NoClassDefFoundError);
+            Assertions.assertTrue(e.getMessage() != null &&
                 e.getMessage().contains(
                     YarnConfiguration.TIMELINE_SERVICE_ENABLED));
           }
@@ -164,7 +166,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         new NoClassDefFoundError("Mock a NoClassDefFoundError"),
         new CreateTimelineClientErrorVerifier(0) {
           @Override public void verifyError(Throwable e) {
-            Assert.fail("NoClassDefFoundError while creating timeline client"
+            Assertions.fail("NoClassDefFoundError while creating timeline client"
                 + "should be tolerated when timeline service is disabled.");
           }
         }
@@ -178,8 +180,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         new NoClassDefFoundError("Mock a NoClassDefFoundError"),
         new CreateTimelineClientErrorVerifier(1) {
           @Override public void verifyError(Throwable e) {
-            Assert.assertTrue(e instanceof NoClassDefFoundError);
-            Assert.assertTrue(e.getMessage() != null &&
+            Assertions.assertTrue(e instanceof NoClassDefFoundError);
+            Assertions.assertTrue(e.getMessage() != null &&
                 e.getMessage().contains(
                     YarnConfiguration.TIMELINE_SERVICE_ENABLED));
           }
@@ -196,7 +198,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         new CreateTimelineClientErrorVerifier(1) {
           @Override
           public void verifyError(Throwable e) {
-            Assert.assertTrue(e instanceof IOException);
+            Assertions.assertTrue(e instanceof IOException);
           }
         }
     );
@@ -211,7 +213,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         new CreateTimelineClientErrorVerifier(0) {
           @Override
           public void verifyError(Throwable e) {
-            Assert.fail("IOException while creating timeline client"
+            Assertions.fail("IOException while creating timeline client"
                 + "should be tolerated when best effort is true");
           }
         }
@@ -219,7 +221,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
   }
 
   @SuppressWarnings("deprecation")
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testSubmitApplication() throws Exception {
     Configuration conf = getConf();
     conf.setLong(YarnConfiguration.YARN_CLIENT_APP_SUBMISSION_POLL_INTERVAL_MS,
@@ -241,10 +244,10 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         mock(ApplicationSubmissionContext.class);
     try {
       client.submitApplication(contextWithoutApplicationId);
-      Assert.fail("Should throw the ApplicationIdNotProvidedException");
+      Assertions.fail("Should throw the ApplicationIdNotProvidedException");
     } catch (YarnException e) {
-      Assert.assertTrue(e instanceof ApplicationIdNotProvidedException);
-      Assert.assertTrue(e.getMessage().contains(
+      Assertions.assertTrue(e instanceof ApplicationIdNotProvidedException);
+      Assertions.assertTrue(e.getMessage().contains(
           "ApplicationId is not provided in ApplicationSubmissionContext"));
     }
 
@@ -266,7 +269,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
   }
 
   @SuppressWarnings("deprecation")
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20)
   public void testSubmitApplicationInterrupted() throws IOException {
     Configuration conf = getConf();
     int pollIntervalMs = 1000;
@@ -311,12 +315,13 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         appSubmitThread.join();
       } catch (InterruptedException e) {
       }
-      Assert.assertTrue("Expected an InterruptedException wrapped inside a " +
-          "YarnException", appSubmitThread.isInterrupted);
+      Assertions.assertTrue(appSubmitThread.isInterrupted, "Expected an InterruptedException wrapped inside a " +
+          "YarnException");
     }
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testSubmitIncorrectQueueToCapacityScheduler() throws IOException {
     MiniYARNCluster cluster = new MiniYARNCluster("testMRAMTokens", 1, 1, 1);
     YarnClient rmClient = null;
@@ -356,9 +361,9 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
 
       // Submit the application to the applications manager
       rmClient.submitApplication(appContext);
-      Assert.fail("Job submission should have thrown an exception");
+      Assertions.fail("Job submission should have thrown an exception");
     } catch (YarnException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to submit"));
+      Assertions.assertTrue(e.getMessage().contains("Failed to submit"));
     } finally {
       if (rmClient != null) {
         rmClient.stop();
@@ -383,7 +388,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
       .forceKillApplication(any(KillApplicationRequest.class));
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testApplicationType() throws Exception {
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
     MockRM rm = new MockRM();
@@ -401,12 +407,13 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
                 .withCredentials(null)
                 .withAppType("MAPREDUCE")
                 .build());
-    Assert.assertEquals("YARN", app.getApplicationType());
-    Assert.assertEquals("MAPREDUCE", app1.getApplicationType());
+    Assertions.assertEquals("YARN", app.getApplicationType());
+    Assertions.assertEquals("MAPREDUCE", app1.getApplicationType());
     rm.stop();
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testApplicationTypeLimit() throws Exception {
     GenericTestUtils.setRootLogLevel(Level.DEBUG);
     MockRM rm = new MockRM();
@@ -423,11 +430,12 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
                 .withCredentials(null)
                 .withAppType("MAPREDUCE-LENGTH-IS-20")
                 .build());
-    Assert.assertEquals("MAPREDUCE-LENGTH-IS-", app1.getApplicationType());
+    Assertions.assertEquals("MAPREDUCE-LENGTH-IS-", app1.getApplicationType());
     rm.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplications() throws YarnException, IOException {
     final YarnClient client = new MockYarnClient();
     client.init(getConf());
@@ -445,13 +453,13 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     reports =
         client.getApplications(appTypes, null);
     assertThat(reports).hasSize(2);
-    Assert
+    Assertions
         .assertTrue((reports.get(0).getApplicationType().equals("YARN") && reports
             .get(1).getApplicationType().equals("NON-YARN"))
             || (reports.get(1).getApplicationType().equals("YARN") && reports
                 .get(0).getApplicationType().equals("NON-YARN")));
     for(ApplicationReport report : reports) {
-      Assert.assertTrue(expectedReports.contains(report));
+      Assertions.assertTrue(expectedReports.contains(report));
     }
 
     EnumSet<YarnApplicationState> appStates =
@@ -460,26 +468,27 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     appStates.add(YarnApplicationState.FAILED);
     reports = client.getApplications(null, appStates);
     assertThat(reports).hasSize(2);
-    Assert
+    Assertions
     .assertTrue((reports.get(0).getApplicationType().equals("NON-YARN") && reports
         .get(1).getApplicationType().equals("NON-MAPREDUCE"))
         || (reports.get(1).getApplicationType().equals("NON-YARN") && reports
             .get(0).getApplicationType().equals("NON-MAPREDUCE")));
     for (ApplicationReport report : reports) {
-      Assert.assertTrue(expectedReports.contains(report));
+      Assertions.assertTrue(expectedReports.contains(report));
     }
 
     reports = client.getApplications(appTypes, appStates);
-    Assert.assertEquals(1, reports.size());
-    Assert.assertEquals("NON-YARN", reports.get(0).getApplicationType());
+    Assertions.assertEquals(1, reports.size());
+    Assertions.assertEquals("NON-YARN", reports.get(0).getApplicationType());
     for (ApplicationReport report : reports) {
-      Assert.assertTrue(expectedReports.contains(report));
+      Assertions.assertTrue(expectedReports.contains(report));
     }
 
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplicationAttempts() throws YarnException, IOException {
     final YarnClient client = new MockYarnClient();
     client.init(getConf());
@@ -488,7 +497,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     ApplicationId applicationId = ApplicationId.newInstance(1234, 5);
     List<ApplicationAttemptReport> reports = client
         .getApplicationAttempts(applicationId);
-    Assert.assertNotNull(reports);
+    Assertions.assertNotNull(reports);
     assertThat(reports.get(0).getApplicationAttemptId()).isEqualTo(
         ApplicationAttemptId.newInstance(applicationId, 1));
     assertThat(reports.get(1).getApplicationAttemptId()).isEqualTo(
@@ -496,7 +505,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetApplicationAttempt() throws YarnException, IOException {
     Configuration conf = new Configuration();
     final YarnClient client = new MockYarnClient();
@@ -511,13 +521,14 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         applicationId, 1);
     ApplicationAttemptReport report = client
         .getApplicationAttemptReport(appAttemptId);
-    Assert.assertNotNull(report);
+    Assertions.assertNotNull(report);
     assertThat(report.getApplicationAttemptId().toString()).isEqualTo(
         expectedReports.get(0).getCurrentApplicationAttemptId().toString());
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetContainers() throws YarnException, IOException {
     Configuration conf = getConf();
     conf.setBoolean(YarnConfiguration.APPLICATION_HISTORY_ENABLED,
@@ -531,7 +542,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         applicationId, 1);
     List<ContainerReport> reports = client.getContainers(appAttemptId);
-    Assert.assertNotNull(reports);
+    Assertions.assertNotNull(reports);
     assertThat(reports.get(0).getContainerId()).isEqualTo(
         (ContainerId.newContainerId(appAttemptId, 1)));
     assertThat(reports.get(1).getContainerId()).isEqualTo(
@@ -541,16 +552,17 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     
     //First2 containers should come from RM with updated state information and 
     // 3rd container is not there in RM and should
-    Assert.assertEquals(ContainerState.RUNNING,
+    Assertions.assertEquals(ContainerState.RUNNING,
         (reports.get(0).getContainerState()));
-    Assert.assertEquals(ContainerState.RUNNING,
+    Assertions.assertEquals(ContainerState.RUNNING,
         (reports.get(1).getContainerState()));
-    Assert.assertEquals(ContainerState.COMPLETE,
+    Assertions.assertEquals(ContainerState.COMPLETE,
         (reports.get(2).getContainerState()));
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetContainersOnAHSFail() throws YarnException, IOException {
     Configuration conf = getConf();
     conf.setBoolean(YarnConfiguration.APPLICATION_HISTORY_ENABLED,
@@ -572,23 +584,24 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
         applicationId, 1);
     List<ContainerReport> reports = client.getContainers(appAttemptId);
-    Assert.assertNotNull(reports);
-    Assert.assertTrue(reports.size() == 2);
+    Assertions.assertNotNull(reports);
+    Assertions.assertTrue(reports.size() == 2);
     assertThat(reports.get(0).getContainerId()).isEqualTo(
         (ContainerId.newContainerId(appAttemptId, 1)));
     assertThat(reports.get(1).getContainerId()).isEqualTo(
         (ContainerId.newContainerId(appAttemptId, 2)));
 
     //Only 2 running containers from RM are present when AHS throws exception
-    Assert.assertEquals(ContainerState.RUNNING,
+    Assertions.assertEquals(ContainerState.RUNNING,
         (reports.get(0).getContainerState()));
-    Assert.assertEquals(ContainerState.RUNNING,
+    Assertions.assertEquals(ContainerState.RUNNING,
         (reports.get(1).getContainerState()));
     client.stop();
   }
 
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetContainerReport() throws YarnException, IOException {
     Configuration conf = getConf();
     conf.setBoolean(YarnConfiguration.APPLICATION_HISTORY_ENABLED,
@@ -605,21 +618,22 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         applicationId, 1);
     ContainerId containerId = ContainerId.newContainerId(appAttemptId, 1);
     ContainerReport report = client.getContainerReport(containerId);
-    Assert.assertNotNull(report);
+    Assertions.assertNotNull(report);
     assertThat(report.getContainerId().toString()).isEqualTo(
         (ContainerId.newContainerId(expectedReports.get(0)
             .getCurrentApplicationAttemptId(), 1)).toString());
     containerId = ContainerId.newContainerId(appAttemptId, 3);
     report = client.getContainerReport(containerId);
-    Assert.assertNotNull(report);
+    Assertions.assertNotNull(report);
     assertThat(report.getContainerId().toString()).isEqualTo(
         (ContainerId.newContainerId(expectedReports.get(0)
             .getCurrentApplicationAttemptId(), 3)).toString());
-    Assert.assertNotNull(report.getExecutionType());
+    Assertions.assertNotNull(report.getExecutionType());
     client.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetLabelsToNodes() throws YarnException, IOException {
     final YarnClient client = new MockYarnClient();
     client.init(getConf());
@@ -644,7 +658,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     client.close();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetNodesToLabels() throws YarnException, IOException {
     final YarnClient client = new MockYarnClient();
     client.init(getConf());
@@ -731,7 +746,7 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
         historyClient = mock(AHSClient.class);
 
       } catch (Exception e) {
-        Assert.fail("Unexpected exception caught: " + e);
+        Assertions.fail("Unexpected exception caught: " + e);
       }
 
       when(mockResponse.getApplicationReport()).thenReturn(mockReport);
@@ -1048,7 +1063,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30)
   public void testAMMRTokens() throws Exception {
     MiniYARNCluster cluster = new MiniYARNCluster("testMRAMTokens", 1, 1, 1);
     YarnClient rmClient = null;
@@ -1063,19 +1079,19 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
       ApplicationId appId = createApp(rmClient, false);
       waitTillAccepted(rmClient, appId, false);
       //managed AMs don't return AMRM token
-      Assert.assertNull(rmClient.getAMRMToken(appId));
+      Assertions.assertNull(rmClient.getAMRMToken(appId));
 
       appId = createApp(rmClient, true);
       waitTillAccepted(rmClient, appId, true);
       long start = System.currentTimeMillis();
       while (rmClient.getAMRMToken(appId) == null) {
         if (System.currentTimeMillis() - start > 20 * 1000) {
-          Assert.fail("AMRM token is null");
+          Assertions.fail("AMRM token is null");
         }
         Thread.sleep(100);
       }
       //unmanaged AMs do return AMRM token
-      Assert.assertNotNull(rmClient.getAMRMToken(appId));
+      Assertions.assertNotNull(rmClient.getAMRMToken(appId));
       
       UserGroupInformation other =
         UserGroupInformation.createUserForTesting("foo", new String[]{});
@@ -1091,17 +1107,17 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
             long start = System.currentTimeMillis();
             while (rmClient.getAMRMToken(appId) == null) {
               if (System.currentTimeMillis() - start > 20 * 1000) {
-                Assert.fail("AMRM token is null");
+                Assertions.fail("AMRM token is null");
               }
               Thread.sleep(100);
             }
             //unmanaged AMs do return AMRM token
-            Assert.assertNotNull(rmClient.getAMRMToken(appId));
+            Assertions.assertNotNull(rmClient.getAMRMToken(appId));
             return appId;
           }
         });
       //other users don't get AMRM token
-      Assert.assertNull(rmClient.getAMRMToken(appId));
+      Assertions.assertNull(rmClient.getAMRMToken(appId));
     } finally {
       if (rmClient != null) {
         rmClient.stop();
@@ -1160,39 +1176,42 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
       Thread.sleep(200);
       report = rmClient.getApplicationReport(appId);
     }
-    Assert.assertEquals(unmanagedApplication, report.isUnmanagedApp());
+    Assertions.assertEquals(unmanagedApplication, report.isUnmanagedApp());
   }
 
-  @Test(timeout = 30000, expected = ApplicationNotFoundException.class)
+  @Test
+  @Timeout(value = 30)
   public void testShouldNotRetryForeverForNonNetworkExceptions() throws Exception {
-    YarnConfiguration conf = getConf();
-    conf.setInt(YarnConfiguration.RESOURCEMANAGER_CONNECT_MAX_WAIT_MS, -1);
+    assertThrows(ApplicationNotFoundException.class, ()->{
+      YarnConfiguration conf = getConf();
+      conf.setInt(YarnConfiguration.RESOURCEMANAGER_CONNECT_MAX_WAIT_MS, -1);
 
-    ResourceManager rm = null;
-    YarnClient yarnClient = null;
-    try {
-      // start rm
-      rm = new ResourceManager();
-      rm.init(conf);
-      rm.start();
+      ResourceManager rm = null;
+      YarnClient yarnClient = null;
+      try {
+        // start rm
+        rm = new ResourceManager();
+        rm.init(conf);
+        rm.start();
 
-      yarnClient = YarnClient.createYarnClient();
-      yarnClient.init(conf);
-      yarnClient.start();
+        yarnClient = YarnClient.createYarnClient();
+        yarnClient.init(conf);
+        yarnClient.start();
 
-      // create invalid application id
-      ApplicationId appId = ApplicationId.newInstance(1430126768L, 10645);
+        // create invalid application id
+        ApplicationId appId = ApplicationId.newInstance(1430126768L, 10645);
 
-      // RM should throw ApplicationNotFoundException exception
-      yarnClient.getApplicationReport(appId);
-    } finally {
-      if (yarnClient != null) {
-        yarnClient.stop();
+        // RM should throw ApplicationNotFoundException exception
+        yarnClient.getApplicationReport(appId);
+      } finally {
+        if (yarnClient != null) {
+          yarnClient.stop();
+        }
+        if (rm != null) {
+          rm.stop();
+        }
       }
-      if (rm != null) {
-        rm.stop();
-      }
-    }
+    });
   }
 
   @Test
@@ -1212,8 +1231,8 @@ public class TestYarnClient extends ParameterizedSchedulerTestBase {
     verify(((MockYarnClient) client).getRMClient())
         .signalToContainer(signalReqCaptor.capture());
     SignalContainerRequest request = signalReqCaptor.getValue();
-    Assert.assertEquals(containerId, request.getContainerId());
-    Assert.assertEquals(command, request.getCommand());
+    Assertions.assertEquals(containerId, request.getContainerId());
+    Assertions.assertEquals(command, request.getCommand());
   }
 
   private void testCreateTimelineClientWithError(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientImpl.java
@@ -50,9 +50,9 @@ import org.apache.hadoop.yarn.security.client.TimelineDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.server.resourcemanager
         .ParameterizedSchedulerTestBase;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.QueueMetrics;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -79,7 +79,7 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
     super(type);
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     QueueMetrics.clearQueueMetrics();
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -116,7 +116,7 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
 
       client.init(conf);
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
               expectedTimeoutEnforcement, client.enforceAsyncAPITimeout());
     } finally {
       IOUtils.closeStream(client);
@@ -152,7 +152,7 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
       conf.setBoolean(YarnConfiguration.TIMELINE_SERVICE_CLIENT_BEST_EFFORT, false);
       client.serviceInit(conf);
       client.getTimelineDelegationToken();
-      Assert.fail("Get delegation token should have thrown an exception");
+      Assertions.fail("Get delegation token should have thrown an exception");
     } catch (IOException e) {
       // Success
     }
@@ -262,10 +262,10 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
       }
       Collection<Token<? extends TokenIdentifier>> dTokens =
            credentials.getAllTokens();
-      Assert.assertEquals("Failed to place token for Log Aggregation Path",
-          1, dTokens.size());
-      Assert.assertEquals("Wrong Token for Log Aggregation",
-          hdfsDT.getKind(), dTokens.iterator().next().getKind());
+      Assertions.assertEquals(
+         1, dTokens.size(), "Failed to place token for Log Aggregation Path");
+      Assertions.assertEquals(
+         hdfsDT.getKind(), dTokens.iterator().next().getKind(), "Wrong Token for Log Aggregation");
 
     } finally {
       if (hdfsCluster != null) {
@@ -356,8 +356,8 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
         }
         Collection<Token<? extends TokenIdentifier>> dTokens =
                 credentials.getAllTokens();
-        Assert.assertEquals(1, dTokens.size());
-        Assert.assertEquals(dToken, dTokens.iterator().next());
+        Assertions.assertEquals(1, dTokens.size());
+        Assertions.assertEquals(dToken, dTokens.iterator().next());
       }
     } finally {
       client.stop();
@@ -376,7 +376,7 @@ public class TestYarnClientImpl extends ParameterizedSchedulerTestBase {
     try {
       client.init(conf);
       client.start();
-      Assert.assertEquals("rm/localhost@EXAMPLE.COM", client.timelineDTRenewer);
+      Assertions.assertEquals("rm/localhost@EXAMPLE.COM", client.timelineDTRenewer);
     } finally {
       client.stop();
     }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientWithReservation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/api/impl/TestYarnClientWithReservation.java
@@ -52,9 +52,9 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair
     .allocationfile.AllocationFileWriter;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.hadoop.yarn.util.UTCClock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -170,14 +170,14 @@ public class TestYarnClientWithReservation {
         reservationID, 4, arrival, deadline, duration);
     ReservationSubmissionResponse sResponse =
         client.submitReservation(sRequest);
-    Assert.assertNotNull(sResponse);
-    Assert.assertNotNull(reservationID);
+    Assertions.assertNotNull(sResponse);
+    Assertions.assertNotNull(reservationID);
     System.out.println("Submit reservation response: " + reservationID);
 
     return sRequest;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     QueueMetrics.clearQueueMetrics();
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -207,11 +207,11 @@ public class TestYarnClientWithReservation {
       sRequest.setReservationDefinition(rDef);
       try {
         client.submitReservation(sRequest);
-        Assert.fail("Reservation submission should fail if a duplicate "
+        Assertions.fail("Reservation submission should fail if a duplicate "
             + "reservation id is used, but the reservation definition has been "
             + "updated.");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof YarnException);
+        Assertions.assertTrue(e instanceof YarnException);
       }
     } finally {
       // clean-up
@@ -248,7 +248,7 @@ public class TestYarnClientWithReservation {
       ReservationUpdateRequest uRequest =
           ReservationUpdateRequest.newInstance(rDef, reservationID);
       ReservationUpdateResponse uResponse = client.updateReservation(uRequest);
-      Assert.assertNotNull(uResponse);
+      Assertions.assertNotNull(uResponse);
       System.out.println("Update reservation response: " + uResponse);
     } finally {
       // clean-up
@@ -296,11 +296,11 @@ public class TestYarnClientWithReservation {
           ReservationSystemTestUtil.reservationQ, reservationID.toString(), -1,
           -1, false);
       ReservationListResponse response = client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(1, response.getReservationAllocationState().size());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(1, response.getReservationAllocationState().size());
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getReservationId().getId(), reservationID.getId());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getResourceAllocationRequests().size(), 0);
     } finally {
       // clean-up
@@ -332,30 +332,30 @@ public class TestYarnClientWithReservation {
           arrival + duration / 2, true);
 
       ReservationListResponse response = client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(1, response.getReservationAllocationState().size());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(1, response.getReservationAllocationState().size());
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getReservationId().getId(), reservationID.getId());
       // List reservations, search by time within reservation interval.
       request = ReservationListRequest.newInstance(
           ReservationSystemTestUtil.reservationQ, "", 1, Long.MAX_VALUE, true);
 
       response = client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(1, response.getReservationAllocationState().size());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(1, response.getReservationAllocationState().size());
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getReservationId().getId(), reservationID.getId());
       // Verify that the full resource allocations exist.
-      Assert.assertTrue(response.getReservationAllocationState().get(0)
+      Assertions.assertTrue(response.getReservationAllocationState().get(0)
           .getResourceAllocationRequests().size() > 0);
 
       // Verify that the full RDL is returned.
       ReservationRequests reservationRequests =
           response.getReservationAllocationState().get(0)
               .getReservationDefinition().getReservationRequests();
-      Assert.assertEquals("R_ALL",
+      Assertions.assertEquals("R_ALL",
           reservationRequests.getInterpreter().toString());
-      Assert.assertTrue(reservationRequests.getReservationResources().get(0)
+      Assertions.assertTrue(reservationRequests.getReservationResources().get(0)
           .getDuration() == duration);
     } finally {
       // clean-up
@@ -383,9 +383,9 @@ public class TestYarnClientWithReservation {
           .newInstance(ReservationSystemTestUtil.reservationQ, "", 1, -1, true);
 
       ReservationListResponse response = client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(1, response.getReservationAllocationState().size());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(1, response.getReservationAllocationState().size());
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getReservationId().getId(), sRequest.getReservationId().getId());
 
       // List reservations, search by invalid end time < -1.
@@ -393,9 +393,9 @@ public class TestYarnClientWithReservation {
           ReservationSystemTestUtil.reservationQ, "", 1, -10, true);
 
       response = client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(1, response.getReservationAllocationState().size());
-      Assert.assertEquals(response.getReservationAllocationState().get(0)
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(1, response.getReservationAllocationState().size());
+      Assertions.assertEquals(response.getReservationAllocationState().get(0)
           .getReservationId().getId(), sRequest.getReservationId().getId());
     } finally {
       // clean-up
@@ -427,7 +427,7 @@ public class TestYarnClientWithReservation {
       ReservationListResponse response = client.listReservations(request);
 
       // Ensure all reservations are filtered out.
-      Assert.assertNotNull(response);
+      Assertions.assertNotNull(response);
       assertThat(response.getReservationAllocationState()).isEmpty();
 
       duration = 30000;
@@ -442,7 +442,7 @@ public class TestYarnClientWithReservation {
       response = client.listReservations(request);
 
       // Ensure all reservations are filtered out.
-      Assert.assertNotNull(response);
+      Assertions.assertNotNull(response);
       assertThat(response.getReservationAllocationState()).isEmpty();
 
       arrival = clock.getTime();
@@ -455,7 +455,7 @@ public class TestYarnClientWithReservation {
       response = client.listReservations(request);
 
       // Ensure all reservations are filtered out.
-      Assert.assertNotNull(response);
+      Assertions.assertNotNull(response);
       assertThat(response.getReservationAllocationState()).isEmpty();
 
       // List reservations, search by very small end time.
@@ -465,7 +465,7 @@ public class TestYarnClientWithReservation {
       response = client.listReservations(request);
 
       // Ensure all reservations are filtered out.
-      Assert.assertNotNull(response);
+      Assertions.assertNotNull(response);
       assertThat(response.getReservationAllocationState()).isEmpty();
 
     } finally {
@@ -494,7 +494,7 @@ public class TestYarnClientWithReservation {
       ReservationDeleteRequest dRequest =
           ReservationDeleteRequest.newInstance(reservationID);
       ReservationDeleteResponse dResponse = client.deleteReservation(dRequest);
-      Assert.assertNotNull(dResponse);
+      Assertions.assertNotNull(dResponse);
       System.out.println("Delete reservation response: " + dResponse);
 
       // List reservations, search by non-existent reservationID
@@ -503,8 +503,8 @@ public class TestYarnClientWithReservation {
           -1, false);
 
       ReservationListResponse response =  client.listReservations(request);
-      Assert.assertNotNull(response);
-      Assert.assertEquals(0, response.getReservationAllocationState().size());
+      Assertions.assertNotNull(response);
+      Assertions.assertEquals(0, response.getReservationAllocationState().size());
     } finally {
       // clean-up
       if (client != null) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestClusterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestClusterCLI.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.yarn.client.cli;
 import org.apache.hadoop.yarn.api.records.NodeAttributeInfo;
 import org.apache.hadoop.yarn.api.records.NodeAttributeKey;
 import org.apache.hadoop.yarn.api.records.NodeAttributeType;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -36,8 +36,8 @@ import java.util.Arrays;
 import org.apache.hadoop.yarn.api.records.NodeLabel;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.nodelabels.CommonNodeLabelsManager;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.thirdparty.com.google.common.collect.ImmutableSet;
 
@@ -49,7 +49,7 @@ public class TestClusterCLI {
   private PrintStream sysErr;
   private YarnClient client = mock(YarnClient.class);
 
-  @Before
+  @BeforeEach
   public void setup() {
     sysOutStream = new ByteArrayOutputStream();
     sysOut = spy(new PrintStream(sysOutStream));

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestGpgCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestGpgCLI.java
@@ -19,18 +19,18 @@ package org.apache.hadoop.yarn.client.cli;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestGpgCLI {
   private GpgCLI gpgCLI;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration config = new Configuration();
     config.setBoolean(YarnConfiguration.FEDERATION_ENABLED, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestLogsCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestLogsCLI.java
@@ -22,9 +22,9 @@ import static org.apache.hadoop.yarn.conf.YarnConfiguration.LOG_AGGREGATION_FILE
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.LOG_AGGREGATION_REMOTE_APP_LOG_DIR_FMT;
 import static org.apache.hadoop.yarn.conf.YarnConfiguration.LOG_AGGREGATION_REMOTE_APP_LOG_DIR_SUFFIX_FMT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -92,10 +92,11 @@ import org.apache.hadoop.yarn.logaggregation.filecontroller.LogAggregationFileCo
 import org.apache.hadoop.yarn.logaggregation.filecontroller.ifile.LogAggregationIndexedFileController;
 import org.apache.hadoop.yarn.webapp.util.WebServiceClient;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +114,7 @@ public class TestLogsCLI {
 
   private Configuration conf;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     sysOutStream = new ByteArrayOutputStream();
     sysOut =  new PrintStream(sysOutStream);
@@ -126,12 +127,13 @@ public class TestLogsCLI {
     WebServiceClient.initialize(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     WebServiceClient.destroy();
   }
 
-  @Test(timeout = 5000l)
+  @Test
+  @Timeout(value = 5)
   public void testFailResultCodes() throws Exception {
     conf.setClass("fs.file.impl", LocalFileSystem.class, FileSystem.class);
     LogCLIHelpers cliHelper = new LogCLIHelpers();
@@ -145,15 +147,16 @@ public class TestLogsCLI {
     // verify dumping a non-existent application's logs returns a failure code
     int exitCode = dumper.run( new String[] {
         "-applicationId", "application_0_0" } );
-    assertTrue("Should return an error code", exitCode != 0);
+    assertTrue(exitCode != 0, "Should return an error code");
 
     // verify dumping a non-existent container log is a failure code
     exitCode = cliHelper.dumpAContainersLogs("application_0_0", "container_0_0",
         "nonexistentnode:1234", "nobody");
-    assertTrue("Should return an error code", exitCode != 0);
+    assertTrue(exitCode != 0, "Should return an error code");
   }
 
-  @Test(timeout = 10000l)
+  @Test
+  @Timeout(value = 10)
   public void testInvalidOpts() throws Exception {
     YarnClient mockYarnClient = createMockYarnClient(
         YarnApplicationState.FINISHED,
@@ -167,7 +170,8 @@ public class TestLogsCLI {
         "options parsing failed: Unrecognized option: -InvalidOpts"));
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5)
   public void testInvalidAMContainerId() throws Exception {
     conf.setBoolean(YarnConfiguration.APPLICATION_HISTORY_ENABLED, true);
     YarnClient mockYarnClient =
@@ -222,7 +226,8 @@ public class TestLogsCLI {
     assertTrue(exitCode == 0);
   }
 
-  @Test(timeout = 5000l)
+  @Test
+  @Timeout(value = 5)
   public void testUnknownApplicationId() throws Exception {
     YarnClient mockYarnClient = createMockYarnClientUnknownApp();
     LogsCLI cli = new LogsCLIForTest(mockYarnClient);
@@ -237,7 +242,8 @@ public class TestLogsCLI {
         "Unable to get ApplicationState"));
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5)
   public void testUnknownApplicationAttemptId() throws Exception {
     YarnClient mockYarnClient = createMockYarnClientUnknownApp();
     LogsCLI cli = new LogsCLIForTest(mockYarnClient);
@@ -253,7 +259,8 @@ public class TestLogsCLI {
             "Unable to get ApplicationState."));
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testHelpMessage() throws Exception {
     YarnClient mockYarnClient = createMockYarnClient(
         YarnApplicationState.FINISHED,
@@ -372,10 +379,11 @@ public class TestLogsCLI {
     pw.println("                                              fetch all logs.");
     pw.close();
     String appReportStr = baos.toString("UTF-8");
-    Assert.assertTrue(sysOutStream.toString().contains(appReportStr));
+    Assertions.assertTrue(sysOutStream.toString().contains(appReportStr));
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testFetchFinishedApplictionLogs() throws Exception {
     String remoteLogRootDir = "target/logs/";
     conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
@@ -578,43 +586,43 @@ public class TestLogsCLI {
     // Check backward compatibility for -logFiles
     exitCode = cli.run(new String[] {"-applicationId", appId.toString(),
         "-logFiles", "stdout"});
-    assertTrue("Failed with -logFiles", exitCode == 0);
-    assertFalse("Failed with -logFiles", sysOutStream.toString().contains(
-        logMessage(containerId1, "syslog")));
-    assertFalse("Failed with -logFiles", sysOutStream.toString().contains(
-        logMessage(containerId2, "syslog")));
-    assertFalse("Failed with -logFiles", sysOutStream.toString().contains(
-        logMessage(containerId3, "syslog")));
-    assertTrue("Failed with -logFiles", sysOutStream.toString().contains(
-        logMessage(containerId3, "stdout")));
-    assertFalse("Failed with -logFiles", sysOutStream.toString().contains(
-        logMessage(containerId3, "stdout1234")));
-    assertFalse("Failed with -logFiles", sysOutStream.toString().contains(
-        createEmptyLog("empty")));
+    assertTrue(exitCode == 0, "Failed with -logFiles");
+    assertFalse(sysOutStream.toString().contains(
+        logMessage(containerId1, "syslog")), "Failed with -logFiles");
+    assertFalse(sysOutStream.toString().contains(
+        logMessage(containerId2, "syslog")), "Failed with -logFiles");
+    assertFalse(sysOutStream.toString().contains(
+        logMessage(containerId3, "syslog")), "Failed with -logFiles");
+    assertTrue(sysOutStream.toString().contains(
+        logMessage(containerId3, "stdout")), "Failed with -logFiles");
+    assertFalse(sysOutStream.toString().contains(
+        logMessage(containerId3, "stdout1234")), "Failed with -logFiles");
+    assertFalse(sysOutStream.toString().contains(
+        createEmptyLog("empty")), "Failed with -logFiles");
     sysOutStream.reset();
 
     // Check -log_files supercedes -logFiles
     exitCode = cli.run(new String[] {"-applicationId", appId.toString(),
         "-log_files", "stdout", "-logFiles", "syslog"});
-    assertTrue("Failed with -logFiles and -log_files", exitCode == 0);
-    assertFalse("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        logMessage(containerId1, "syslog")));
-    assertFalse("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        logMessage(containerId2, "syslog")));
-    assertFalse("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        logMessage(containerId3, "syslog")));
-    assertTrue("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        logMessage(containerId3, "stdout")));
-    assertFalse("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        logMessage(containerId3, "stdout1234")));
-    assertFalse("Failed with -logFiles and -log_files",
-        sysOutStream.toString().contains(
-        createEmptyLog("empty")));
+    assertTrue(exitCode == 0, "Failed with -logFiles and -log_files");
+    assertFalse(
+       sysOutStream.toString().contains(
+        logMessage(containerId1, "syslog")), "Failed with -logFiles and -log_files");
+    assertFalse(
+       sysOutStream.toString().contains(
+        logMessage(containerId2, "syslog")), "Failed with -logFiles and -log_files");
+    assertFalse(
+       sysOutStream.toString().contains(
+        logMessage(containerId3, "syslog")), "Failed with -logFiles and -log_files");
+    assertTrue(
+       sysOutStream.toString().contains(
+        logMessage(containerId3, "stdout")), "Failed with -logFiles and -log_files");
+    assertFalse(
+       sysOutStream.toString().contains(
+        logMessage(containerId3, "stdout1234")), "Failed with -logFiles and -log_files");
+    assertFalse(
+       sysOutStream.toString().contains(
+        createEmptyLog("empty")), "Failed with -logFiles and -log_files");
     sysOutStream.reset();
 
     exitCode = cli.run(new String[] {"-applicationId", appId.toString(),
@@ -697,7 +705,7 @@ public class TestLogsCLI {
         "-containerId", containerId3.toString(), "-log_files", "stdout",
         "-size", "5"});
     assertTrue(exitCode == 0);
-    Assert.assertEquals(new String(logMessage.getBytes(), 0, 5),
+    Assertions.assertEquals(new String(logMessage.getBytes(), 0, 5),
         new String(sysOutStream.toByteArray(),
         (fullContextSize - fileContentSize - tailContentSize), 5));
     sysOutStream.reset();
@@ -717,7 +725,7 @@ public class TestLogsCLI {
         "-containerId", containerId3.toString(), "-log_files", "stdout",
         "-size", "-5"});
     assertTrue(exitCode == 0);
-    Assert.assertEquals(new String(logMessage.getBytes(),
+    Assertions.assertEquals(new String(logMessage.getBytes(),
         logMessage.getBytes().length - 5, 5),
         new String(sysOutStream.toByteArray(),
         (fullContextSize - fileContentSize - tailContentSize), 5));
@@ -728,7 +736,7 @@ public class TestLogsCLI {
         "-containerId", containerId3.toString(), "-log_files", "stdout",
         "-size", Long.toString(negative)});
     assertTrue(exitCode == 0);
-    Assert.assertEquals(fullContext, sysOutStream.toString());
+    Assertions.assertEquals(fullContext, sysOutStream.toString());
     sysOutStream.reset();
 
     // Uploaded the empty log for container0.
@@ -858,16 +866,17 @@ public class TestLogsCLI {
     try {
       cli.run(new String[] {"-containerId",
           containerId1.toString(), "-client_max_retries", "5"});
-      Assert.fail("Exception expected! "
+      Assertions.fail("Exception expected! "
           + "NodeManager should be off to run this test. ");
     } catch (IOException ce) {
-      Assert.assertTrue(
-          "Handler exception for reason other than retry: " + ce.getMessage(),
-          ce.getMessage().contains("Connection retries limit exceeded"));
+      Assertions.assertTrue(
+      
+         ce.getMessage().contains("Connection retries limit exceeded"), "Handler exception for reason other than retry: " + ce.getMessage());
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testGetRunningContainerLogs() throws Exception {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
 
@@ -956,7 +965,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testFetchRunningApplicationLogs() throws Exception {
 
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
@@ -1028,11 +1038,11 @@ public class TestLogsCLI {
     // Verify that the log-type is "ALL"
     List<ContainerLogsRequest> capturedRequests =
         logsRequestCaptor.getAllValues();
-    Assert.assertEquals(2, capturedRequests.size());
+    Assertions.assertEquals(2, capturedRequests.size());
     Set<String> logTypes0 = capturedRequests.get(0).getLogTypes();
     Set<String> logTypes1 = capturedRequests.get(1).getLogTypes();
-    Assert.assertTrue(logTypes0.contains("ALL") && (logTypes0.size() == 1));
-    Assert.assertTrue(logTypes1.contains("ALL") && (logTypes1.size() == 1));
+    Assertions.assertTrue(logTypes0.contains("ALL") && (logTypes0.size() == 1));
+    Assertions.assertTrue(logTypes1.contains("ALL") && (logTypes1.size() == 1));
 
     mockYarnClient = createMockYarnClientWithException(
         YarnApplicationState.RUNNING, ugi.getShortUserName());
@@ -1057,7 +1067,8 @@ public class TestLogsCLI {
         any(LogCLIHelpers.class), anyBoolean(), anyBoolean());
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testFetchApplictionLogsAsAnotherUser() throws Exception {
     String remoteLogRootDir = "target/logs/";
     String rootLogDir = "target/LocalLogs";
@@ -1208,7 +1219,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithInvalidApplicationId() throws Exception {
     LogsCLI cli = createCli();
 
@@ -1219,7 +1231,8 @@ public class TestLogsCLI {
             "Invalid ApplicationId specified"));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithInvalidAppAttemptId() throws Exception {
     LogsCLI cli = createCli();
 
@@ -1231,7 +1244,8 @@ public class TestLogsCLI {
     sysErrStream.reset();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithInvalidContainerId() throws Exception {
     LogsCLI cli = createCli();
 
@@ -1243,7 +1257,8 @@ public class TestLogsCLI {
     sysErrStream.reset();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithNonMatchingEntityIds() throws Exception {
     ApplicationId appId1 = ApplicationId.newInstance(0, 1);
     ApplicationId appId2 = ApplicationId.newInstance(0, 2);
@@ -1282,7 +1297,8 @@ public class TestLogsCLI {
     sysErrStream.reset();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithExclusiveArguments() throws Exception {
     ApplicationId appId1 = ApplicationId.newInstance(0, 1);
     LogsCLI cli = createCli();
@@ -1308,7 +1324,8 @@ public class TestLogsCLI {
     sysErrStream.reset();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testWithFileInputForOptionOut() throws Exception {
     String localDir = "target/SaveLogs";
     Path localPath = new Path(localDir);
@@ -1334,7 +1351,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testGuessAppOwnerWithCustomSuffix() throws Exception {
     String remoteLogRootDir = "target/logs/";
     String jobUser = "user1";
@@ -1378,7 +1396,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testGuessAppOwnerWithCustomAppLogDir() throws Exception {
     String remoteLogRootDir = "target/logs/";
     String remoteLogRootDir1 = "target/logs1/";
@@ -1411,7 +1430,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testSaveContainerLogsLocally() throws Exception {
     String remoteLogRootDir = "target/logs/";
     String rootLogDir = "target/LocalLogs";
@@ -1499,7 +1519,8 @@ public class TestLogsCLI {
     }
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testPrintContainerLogMetadata() throws Exception {
     String remoteLogRootDir = "target/logs/";
     conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
@@ -1603,7 +1624,8 @@ public class TestLogsCLI {
     fs.delete(new Path(rootLogDir), true);
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testListNodeInfo() throws Exception {
     String remoteLogRootDir = "target/logs/";
     conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);
@@ -1653,7 +1675,8 @@ public class TestLogsCLI {
     fs.delete(new Path(rootLogDir), true);
   }
 
-  @Test (timeout = 15000)
+  @Test
+  @Timeout(value = 15)
   public void testFetchApplictionLogsHar() throws Exception {
     String remoteLogRootDir = "target/logs/";
     conf.setBoolean(YarnConfiguration.LOG_AGGREGATION_ENABLED, true);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestNodeAttributesCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestNodeAttributesCLI.java
@@ -32,8 +32,8 @@ import org.apache.hadoop.yarn.api.protocolrecords.GetNodesToAttributesResponse;
 import org.apache.hadoop.yarn.api.records.NodeAttributeInfo;
 import org.apache.hadoop.yarn.api.records.NodeAttributeKey;
 import org.apache.hadoop.yarn.api.records.NodeToAttributeValue;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,8 +54,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.AttributeMappingOperati
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodeToAttributes;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodesToAttributesMappingRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.NodesToAttributesMappingResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -78,7 +78,7 @@ public class TestNodeAttributesCLI {
   private String errOutput;
   private String sysOutput;
 
-  @Before
+  @BeforeEach
   public void configure() throws IOException, YarnException {
 
     admin = mock(ResourceManagerAdministrationProtocol.class);
@@ -126,7 +126,7 @@ public class TestNodeAttributesCLI {
   @Test
   public void testHelp() throws Exception {
     String[] args = new String[] {"-help", "-replace"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-replace <\"node1:attribute[(type)][=value],attribute1"
         + "[=value],attribute2  node2:attribute2[=value],attribute3\">");
     assertErrorContains("Replace the node to attributes mapping information at"
@@ -137,14 +137,14 @@ public class TestNodeAttributesCLI {
         + " attribute to attribute type mapping.");
 
     args = new String[] {"-help", "-remove"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains(
         "-remove <\"node1:attribute,attribute1" + " node2:attribute2\">");
     assertErrorContains("Removes the specified node to attributes mapping"
         + " information at the ResourceManager");
 
     args = new String[] {"-help", "-add"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-add <\"node1:attribute[(type)][=value],"
         + "attribute1[=value],attribute2  node2:attribute2[=value],"
         + "attribute3\">");
@@ -156,33 +156,33 @@ public class TestNodeAttributesCLI {
         + " existing attribute to attribute type mapping.");
 
     args = new String[] {"-help", "-failOnUnknownNodes"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-failOnUnknownNodes");
     assertErrorContains("Can be used optionally along with [add,remove,"
         + "replace] options. When set, command will fail if specified nodes "
         + "are unknown.");
 
     args = new String[] {"-help", "-list"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-list");
     assertErrorContains("List all attributes in cluster");
 
     args = new String[] {"-help", "-nodes"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-nodes");
     assertErrorContains(
         "Works with [list] to specify node hostnames whose mappings "
             + "are required to be displayed.");
 
     args = new String[] {"-help", "-attributes"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-attributes");
     assertErrorContains(
         "Works with [attributestonodes] to specify attributes whose mapping "
             + "are required to be displayed.");
 
     args = new String[] {"-help", "-attributestonodes"};
-    assertTrue("It should have succeeded help for replace", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "It should have succeeded help for replace");
     assertErrorContains("-attributestonodes");
     assertErrorContains("Displays mapping of attributes to nodes and attribute "
         + "values grouped by attributes");
@@ -195,27 +195,27 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     // parenthesis not match
     String[] args = new String[] {"-replace", "x("};
-    assertTrue("It should have failed as no node is specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should have failed as no node is specified");
     assertFailureMessageContains(NodeAttributesCLI.INVALID_MAPPING_ERR_MSG);
 
     // parenthesis not match
     args = new String[] {"-replace", "x:(=abc"};
     assertTrue(
-        "It should have failed as no closing parenthesis is not specified",
-        0 != runTool(args));
+    
+       0 != runTool(args), "It should have failed as no closing parenthesis is not specified");
     assertFailureMessageContains(
         "Attribute for node x is not properly configured : (=abc");
 
     args = new String[] {"-replace", "x:()=abc"};
-    assertTrue("It should have failed as no type specified inside parenthesis",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should have failed as no type specified inside parenthesis");
     assertFailureMessageContains(
         "Attribute for node x is not properly configured : ()=abc");
 
     args = new String[] {"-replace", ":x(string)"};
-    assertTrue("It should have failed as no node is specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should have failed as no node is specified");
     assertFailureMessageContains("Node name cannot be empty");
 
     // Not expected key=value specifying inner parenthesis
@@ -226,15 +226,15 @@ public class TestNodeAttributesCLI {
 
     // Should fail as no attributes specified
     args = new String[] {"-replace"};
-    assertTrue("Should fail as no attribute mappings specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "Should fail as no attribute mappings specified");
     assertFailureMessageContains(NodeAttributesCLI.MISSING_ARGUMENT);
 
     // no labels, should fail
     args = new String[] {"-replace", "-failOnUnknownNodes",
         "x:key(string)=value,key2=val2"};
-    assertTrue("Should fail as no attribute mappings specified for replace",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "Should fail as no attribute mappings specified for replace");
     assertFailureMessageContains(NodeAttributesCLI.MISSING_ARGUMENT);
 
     // no labels, should fail
@@ -250,8 +250,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     args = new String[] {"-replace",
         "x:key(string)=value,key2=val2 y:key2=val23,key3 z:key4"};
-    assertTrue("Should not fail as attribute has been properly mapped",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "Should not fail as attribute has been properly mapped");
     List<NodeToAttributes> nodeAttributesList = new ArrayList<>();
     List<NodeAttribute> attributes = new ArrayList<>();
     attributes.add(
@@ -295,8 +295,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     // parenthesis not match
     String[] args = new String[] {"-remove", "x:"};
-    assertTrue("It should have failed as no node is specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should have failed as no node is specified");
     assertFailureMessageContains(
         "Attributes cannot be null or empty for Operation [remove] on the "
             + "node x");
@@ -305,8 +305,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     args =
         new String[] {"-remove", "x:key2,key3 z:key4", "-failOnUnknownNodes"};
-    assertTrue("Should not fail as attribute has been properly mapped",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "Should not fail as attribute has been properly mapped");
     List<NodeToAttributes> nodeAttributesList = new ArrayList<>();
     List<NodeAttribute> attributes = new ArrayList<>();
     attributes
@@ -334,8 +334,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     // parenthesis not match
     String[] args = new String[] {"-add", "x:"};
-    assertTrue("It should have failed as no node is specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should have failed as no node is specified");
     assertFailureMessageContains(
         "Attributes cannot be null or empty for Operation [add] on the node x");
     // --------------------------------
@@ -343,8 +343,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     args = new String[] {"-add", "x:key2=123,key3=abc z:key4(string)",
         "-failOnUnknownNodes"};
-    assertTrue("Should not fail as attribute has been properly mapped",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "Should not fail as attribute has been properly mapped");
     List<NodeToAttributes> nodeAttributesList = new ArrayList<>();
     List<NodeAttribute> attributes = new ArrayList<>();
     attributes.add(
@@ -369,8 +369,8 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     args = new String[] {"-add", "x:key2=123,key3=abc x:key4(string)",
         "-failOnUnknownNodes"};
-    assertTrue("Should not fail as attribute has been properly mapped",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "Should not fail as attribute has been properly mapped");
     nodeAttributesList = new ArrayList<>();
     attributes = new ArrayList<>();
     attributes
@@ -406,8 +406,8 @@ public class TestNodeAttributesCLI {
     // Success scenarios
     // --------------------------------
     String[] args = new String[] {"-list"};
-    assertTrue("It should be success since it list all attributes",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "It should be success since it list all attributes");
     assertSysOutContains("Attribute\t           Type",
         "rm.yarn.io/GPU\t         STRING");
   }
@@ -433,21 +433,21 @@ public class TestNodeAttributesCLI {
     // Failure scenarios
     // --------------------------------
     String[] args = new String[] {"-nodetoattributes", "-nodes"};
-    assertTrue("It should not success since nodes are not specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should not success since nodes are not specified");
     assertErrorContains(NodeAttributesCLI.INVALID_COMMAND_USAGE);
 
     // Missing argument for nodes
     args = new String[] {"-nodestoattributes", "-nodes"};
-    assertTrue("It should not success since nodes are not specified",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should not success since nodes are not specified");
     assertErrorContains(NodeAttributesCLI.MISSING_ARGUMENT);
 
     // --------------------------------
     // Success with hostname param
     // --------------------------------
     args = new String[] {"-nodestoattributes", "-nodes", "hostname"};
-    assertTrue("Should return hostname to attributed list", 0 == runTool(args));
+    assertTrue(0 == runTool(args), "Should return hostname to attributed list");
     assertSysOutContains("hostname");
   }
 
@@ -473,8 +473,8 @@ public class TestNodeAttributesCLI {
     // Success scenarios
     // --------------------------------
     String[] args = new String[] {"-attributestonodes"};
-    assertTrue("It should be success since it list all attributes",
-        0 == runTool(args));
+    assertTrue(
+       0 == runTool(args), "It should be success since it list all attributes");
     assertSysOutContains("Hostname\tAttribute-value", "rm.yarn.io/GPU :",
         "host1\t            ARM");
 
@@ -483,16 +483,16 @@ public class TestNodeAttributesCLI {
     // --------------------------------
     args = new String[] {"-attributestonodes", "-attributes"};
     assertTrue(
-        "It should not success since attributes for filter are not specified",
-        0 != runTool(args));
+    
+       0 != runTool(args), "It should not success since attributes for filter are not specified");
     assertErrorContains(NodeAttributesCLI.MISSING_ARGUMENT);
 
     // --------------------------------
     // fail scenario argument filter missing
     // --------------------------------
     args = new String[] {"-attributestonodes", "-attributes", "fail/da/fail"};
-    assertTrue("It should not success since attributes format is not correct",
-        0 != runTool(args));
+    assertTrue(
+       0 != runTool(args), "It should not success since attributes format is not correct");
     assertErrorContains(
         "Attribute format not correct. Should be <[prefix]/[name]> "
             + ":fail/da/fail");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRMAdminCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRMAdminCLI.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.yarn.client.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -77,9 +77,9 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.UpdateNodeResourceReque
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.resource.ResourceUtils;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -100,7 +100,7 @@ public class TestRMAdminCLI {
   private static final String HOST_B = "1.2.3.2";
   private static File dest;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     ResourceUtils.resetResourceTypes();
     Configuration yarnConf = new YarnConfiguration();
@@ -113,7 +113,7 @@ public class TestRMAdminCLI {
     ResourceUtils.getResourceTypes();
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (dest.exists()) {
       dest.delete();
@@ -121,7 +121,7 @@ public class TestRMAdminCLI {
   }
 
   @SuppressWarnings("static-access")
-  @Before
+  @BeforeEach
   public void configure() throws IOException, YarnException {
     remoteAdminServiceAccessed = false;
     admin = mock(ResourceManagerAdministrationProtocol.class);
@@ -275,12 +275,12 @@ public class TestRMAdminCLI {
     NodeId nodeId = NodeId.fromString(nodeIdStr);
     Resource expectedResource = Resources.createResource(memSize, cores);
     ResourceOption resource = resourceMap.get(nodeId);
-    assertNotNull("resource for " + nodeIdStr + " shouldn't be null.",
-        resource);
-    assertEquals("resource value for " + nodeIdStr + " is not as expected.",
-        ResourceOption.newInstance(expectedResource,
-            ResourceOption.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT),
-        resource);
+    assertNotNull(
+       resource, "resource for " + nodeIdStr + " shouldn't be null.");
+    assertEquals(
+       ResourceOption.newInstance(expectedResource,
+            ResourceOption.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT)
+,         resource, "resource value for " + nodeIdStr + " is not as expected.");
   }
 
   @Test
@@ -301,10 +301,10 @@ public class TestRMAdminCLI {
     NodeId nodeId = NodeId.fromString(nodeIdStr);
     Resource expectedResource = Resources.createResource(memSize, cores);
     ResourceOption resource = resourceMap.get(nodeId);
-    assertNotNull("resource for " + nodeIdStr + " shouldn't be null.",
-        resource);
-    assertEquals("resource value for " + nodeIdStr + " is not as expected.",
-        ResourceOption.newInstance(expectedResource, timeout), resource);
+    assertNotNull(
+       resource, "resource for " + nodeIdStr + " shouldn't be null.");
+    assertEquals(
+       ResourceOption.newInstance(expectedResource, timeout), resource, "resource value for " + nodeIdStr + " is not as expected.");
   }
 
   @Test
@@ -347,11 +347,11 @@ public class TestRMAdminCLI {
         resource.getResource().getResourceInformation("memory-mb").getValue());
     assertEquals("Mi",
         resource.getResource().getResourceInformation("memory-mb").getUnits());
-    assertNotNull("resource for " + nodeIdStr + " shouldn't be null.",
-        resource);
-    assertEquals("resource value for " + nodeIdStr + " is not as expected.",
-        ResourceOption.newInstance(expectedResource,
-            ResourceOption.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT), resource);
+    assertNotNull(
+       resource, "resource for " + nodeIdStr + " shouldn't be null.");
+    assertEquals(
+       ResourceOption.newInstance(expectedResource,
+            ResourceOption.OVER_COMMIT_TIMEOUT_MILLIS_DEFAULT), resource, "resource value for " + nodeIdStr + " is not as expected.");
   }
 
   @Test
@@ -378,10 +378,10 @@ public class TestRMAdminCLI {
         ResourceInformation.newInstance("resource2", "m", 2));
 
     ResourceOption resource = resourceMap.get(nodeId);
-    assertNotNull("resource for " + nodeIdStr + " shouldn't be null.",
-        resource);
-    assertEquals("resource value for " + nodeIdStr + " is not as expected.",
-        ResourceOption.newInstance(expectedResource, timeout), resource);
+    assertNotNull(
+       resource, "resource for " + nodeIdStr + " shouldn't be null.");
+    assertEquals(
+       ResourceOption.newInstance(expectedResource, timeout), resource, "resource value for " + nodeIdStr + " is not as expected.");
   }
 
   @Test
@@ -807,9 +807,9 @@ public class TestRMAdminCLI {
               + "[-getServiceState <serviceId>] [-getAllServiceState] "
               + "[-checkHealth <serviceId>] [-help [cmd]]";
       String actualHelpMsg = dataOut.toString();
-      assertTrue(String.format("Help messages: %n " + actualHelpMsg + " %n doesn't include expected " +
-          "messages: %n" + expectedHelpMsg), actualHelpMsg.contains(expectedHelpMsg
-              ));
+      assertTrue(actualHelpMsg.contains(expectedHelpMsg
+              ), String.format("Help messages: %n " + actualHelpMsg + " %n doesn't include expected " +
+          "messages: %n" + expectedHelpMsg));
     } finally {
       System.setOut(oldOutPrintStream);
       System.setErr(oldErrPrintStream);
@@ -1039,18 +1039,18 @@ public class TestRMAdminCLI {
 
     args = new String[] { "-replaceLabelsOnNode", "node1= node2=",
         "-directlyAccessNodeLabelStore" };
-    assertTrue("Labels should get replaced even '=' is used ",
-        0 == rmAdminCLI.run(args));
+    assertTrue(
+       0 == rmAdminCLI.run(args), "Labels should get replaced even '=' is used ");
   }
 
   private void testError(String[] args, String template,
       ByteArrayOutputStream data, int resultCode) throws Exception {
     int actualResultCode = rmAdminCLI.run(args);
-    assertEquals("Expected result code: " + resultCode + 
-        ", actual result code is: " + actualResultCode, resultCode, actualResultCode);
-    assertTrue(String.format("Expected error message: %n" + template + 
-        " is not included in messages: %n" + data.toString()), 
-        data.toString().contains(template));
+    assertEquals(resultCode, actualResultCode, "Expected result code: " + resultCode + 
+        ", actual result code is: " + actualResultCode);
+    assertTrue(
+        data.toString().contains(template), String.format("Expected error message: %n" + template + 
+        " is not included in messages: %n" + data.toString()));
     data.reset();
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestRouterCLI.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.yarn.server.api.protocolrecords.GetSubClustersRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.GetSubClustersResponse;
 import org.apache.hadoop.yarn.server.api.protocolrecords.DeleteFederationQueuePoliciesRequest;
 import org.apache.hadoop.yarn.server.api.protocolrecords.DeleteFederationQueuePoliciesResponse;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
@@ -47,8 +47,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,7 +59,7 @@ public class TestRouterCLI {
   private RouterCLI rmAdminCLI;
   private final static int SUBCLUSTER_NUM = 4;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
 
     admin = mock(ResourceManagerAdministrationProtocol.class);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestSchedConfCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestSchedConfCLI.java
@@ -23,8 +23,9 @@ import org.glassfish.jersey.jettison.JettisonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -58,10 +59,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Application;
 
 import static org.apache.hadoop.yarn.webapp.JerseyTestBase.JERSEY_RANDOM_PORT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -139,7 +140,7 @@ public class TestSchedConfCLI extends JerseyTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     cli = new SchedConfCLI();
@@ -171,22 +172,24 @@ public class TestSchedConfCLI extends JerseyTest {
     super.tearDown();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGetSchedulerConf() throws Exception {
     ByteArrayOutputStream sysOutStream = new ByteArrayOutputStream();
     PrintStream sysOut = new PrintStream(sysOutStream);
     System.setOut(sysOut);
     try {
       int exitCode = cli.getSchedulerConf("", target());
-      assertEquals("SchedConfCLI failed to run", 0, exitCode);
-      assertTrue("Failed to get scheduler configuration",
-          sysOutStream.toString().contains("testqueue"));
+      assertEquals(0, exitCode, "SchedConfCLI failed to run");
+      assertTrue(
+         sysOutStream.toString().contains("testqueue"), "Failed to get scheduler configuration");
     } finally {
       cleanUp();
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testFormatSchedulerConf() throws Exception {
     try {
       ResourceScheduler scheduler = rm.getResourceScheduler();
@@ -216,7 +219,8 @@ public class TestSchedConfCLI extends JerseyTest {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testInvalidConf() throws Exception {
     ByteArrayOutputStream sysErrStream = new ByteArrayOutputStream();
     PrintStream sysErr = new PrintStream(sysErrStream);
@@ -232,12 +236,13 @@ public class TestSchedConfCLI extends JerseyTest {
   private void executeCommand(ByteArrayOutputStream sysErrStream, String op,
       String queueConf) throws Exception {
     int exitCode = cli.run(new String[] {op, queueConf});
-    assertNotEquals("Should return an error code", 0, exitCode);
+    assertNotEquals(0, exitCode, "Should return an error code");
     assertTrue(sysErrStream.toString()
         .contains("Specify configuration key " + "value as confKey=confVal."));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testAddQueues() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.addQueues("root.a:a1=aVal1,a2=aVal2,a3=", schedUpdateInfo);
@@ -260,7 +265,8 @@ public class TestSchedConfCLI extends JerseyTest {
     validateQueueConfigInfo(addQueueInfo, 1, "root.c", paramValues);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testAddQueuesWithCommaInValue() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.addQueues("root.a:a1=a1Val1\\,a1Val2 a1Val3,a2=a2Val1\\,a2Val2",
@@ -272,7 +278,8 @@ public class TestSchedConfCLI extends JerseyTest {
     validateQueueConfigInfo(addQueueInfo, 0, "root.a", params);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testRemoveQueues() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.removeQueues("root.a;root.b;root.c.c1", schedUpdateInfo);
@@ -283,7 +290,8 @@ public class TestSchedConfCLI extends JerseyTest {
     assertEquals("root.c.c1", removeInfo.get(2));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testUpdateQueues() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     Map<String, String> paramValues = new HashMap<>();
@@ -317,7 +325,8 @@ public class TestSchedConfCLI extends JerseyTest {
     paramValues.forEach((k, v) -> assertEquals(v, params.get(k)));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testUpdateQueuesWithCommaInValue() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.updateQueues("root.a:a1=a1Val1\\,a1Val2 a1Val3,a2=a2Val1\\,a2Val2",
@@ -330,7 +339,8 @@ public class TestSchedConfCLI extends JerseyTest {
     validateQueueConfigInfo(updateQueueInfo, 0, "root.a", paramValues);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGlobalUpdate() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.globalUpdates("schedKey1=schedVal1,schedKey2=schedVal2",
@@ -341,7 +351,8 @@ public class TestSchedConfCLI extends JerseyTest {
     validateGlobalParams(schedUpdateInfo, paramValues);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testGlobalUpdateWithCommaInValue() {
     SchedConfUpdateInfo schedUpdateInfo = new SchedConfUpdateInfo();
     cli.globalUpdates(

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestTopCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestTopCLI.java
@@ -36,12 +36,12 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.yarn.api.records.YarnClusterMetrics;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for TopCli.
@@ -60,7 +60,7 @@ public class TestTopCLI {
   private PrintStream stdout;
   private PrintStream stderr;
 
-  @BeforeClass
+  @BeforeAll
   public static void initializeDummyHostnameResolution() throws Exception {
     String previousIpAddress;
     for (String hostName : dummyHostNames) {
@@ -72,7 +72,7 @@ public class TestTopCLI {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void restoreDummyHostnameResolution() throws Exception {
     for (Map.Entry<String, String> hostnameToIpEntry : savedStaticResolution
         .entrySet()) {
@@ -81,13 +81,13 @@ public class TestTopCLI {
     }
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     this.stdout = System.out;
     this.stderr = System.err;
   }
 
-  @After
+  @AfterEach
   public void after() {
     System.setOut(this.stdout);
     System.setErr(this.stderr);
@@ -108,11 +108,11 @@ public class TestTopCLI {
     topcli.getConf().set(YarnConfiguration.RM_HA_IDS,
         RM1_NODE_ID + "," + RM2_NODE_ID);
     URL clusterUrl = topcli.getHAClusterUrl(conf, RM1_NODE_ID);
-    Assert.assertEquals("http", clusterUrl.getProtocol());
-    Assert.assertEquals(rm1Address, clusterUrl.getAuthority());
+    Assertions.assertEquals("http", clusterUrl.getProtocol());
+    Assertions.assertEquals(rm1Address, clusterUrl.getAuthority());
     clusterUrl = topcli.getHAClusterUrl(conf, RM2_NODE_ID);
-    Assert.assertEquals("http", clusterUrl.getProtocol());
-    Assert.assertEquals(rm2Address, clusterUrl.getAuthority());
+    Assertions.assertEquals("http", clusterUrl.getProtocol());
+    Assertions.assertEquals(rm2Address, clusterUrl.getAuthority());
     // https
     rm1Address = "host2:9088";
     rm2Address = "host3:9088";
@@ -125,8 +125,8 @@ public class TestTopCLI {
     conf.set(YarnConfiguration.RM_HA_IDS, RM1_NODE_ID + "," + RM2_NODE_ID);
     conf.set(YarnConfiguration.YARN_HTTP_POLICY_KEY, "HTTPS_ONLY");
     clusterUrl = topcli.getHAClusterUrl(conf, RM1_NODE_ID);
-    Assert.assertEquals("https", clusterUrl.getProtocol());
-    Assert.assertEquals(rm1Address, clusterUrl.getAuthority());
+    Assertions.assertEquals("https", clusterUrl.getProtocol());
+    Assertions.assertEquals(rm1Address, clusterUrl.getAuthority());
   }
 
   @Test
@@ -164,8 +164,8 @@ public class TestTopCLI {
     String expected = "NodeManager(s)"
         + ": 0 total, 3 active, 5 unhealthy, 1 decommissioning,"
         + " 2 decommissioned, 4 lost, 6 rebooted, 7 shutdown";
-    Assert.assertTrue(
-        String.format("Expected output to contain [%s], actual output was [%s].", expected, actual),
-        actual.contains(expected));
+    Assertions.assertTrue(
+    
+       actual.contains(expected), String.format("Expected output to contain [%s], actual output was [%s].", expected, actual));
   }
 }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/cli/TestYarnCLI.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.yarn.client.cli;
 import org.apache.hadoop.yarn.api.records.NodeAttribute;
 import org.apache.hadoop.yarn.api.records.NodeAttributeType;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isA;
@@ -99,9 +99,10 @@ import org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.Capacity
 import org.apache.hadoop.yarn.util.Records;
 import org.apache.hadoop.yarn.util.Times;
 import static org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacitySchedulerConfiguration.PREFIX;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.eclipse.jetty.util.log.Log;
 
 import org.slf4j.Logger;
@@ -119,7 +120,7 @@ public class TestYarnCLI {
   private static final Pattern SPACES_PATTERN =
       Pattern.compile("\\s+|\\n+|\\t+");
 
-  @Before
+  @BeforeEach
   public void setup() {
     sysOutStream = new ByteArrayOutputStream();
     sysOut = spy(new PrintStream(sysOutStream));
@@ -197,7 +198,7 @@ public class TestYarnCLI {
       pw.println();
       pw.close();
       String appReportStr = baos.toString("UTF-8");
-      Assert.assertEquals(appReportStr, sysOutStream.toString());
+      Assertions.assertEquals(appReportStr, sysOutStream.toString());
       sysOutStream.reset();
       verify(sysOut, times(1 + i)).println(isA(String.class));
     }
@@ -233,7 +234,7 @@ public class TestYarnCLI {
     pw.println("\tDiagnostics : diagnostics");
     pw.close();
     String appReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appReportStr, sysOutStream.toString());
     verify(sysOut, times(1)).println(isA(String.class));
   }
   
@@ -279,7 +280,7 @@ public class TestYarnCLI {
     pw.println("\t                                url");
     pw.close();
     String appReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appReportStr, sysOutStream.toString());
   }
   
   @Test
@@ -322,7 +323,7 @@ public class TestYarnCLI {
     pw.close();
     String appReportStr = baos.toString("UTF-8");
 
-    Assert.assertEquals(appReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appReportStr, sysOutStream.toString());
     verify(sysOut, times(1)).println(isA(String.class));
   }
   
@@ -386,7 +387,7 @@ public class TestYarnCLI {
     Log.getLog().info("OutputFrom command");
     String actualOutput = sysOutStream.toString("UTF-8");
     Log.getLog().info("["+actualOutput+"]");
-    Assert.assertEquals(appReportStr, actualOutput);
+    Assertions.assertEquals(appReportStr, actualOutput);
   }
   
   @Test
@@ -401,7 +402,7 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Application with id '" + applicationId
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
   }
 
   @Test
@@ -516,7 +517,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     String appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(1)).write(any(byte[].class), anyInt(), anyInt());
 
     //Test command yarn application -list --appTypes apptype1,apptype2
@@ -557,7 +558,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(2)).write(any(byte[].class), anyInt(), anyInt());
 
     //Test command yarn application -list --appStates appState1,appState2
@@ -598,7 +599,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(3)).write(any(byte[].class), anyInt(), anyInt());
 
     // Test command yarn application -list --appTypes apptype1,apptype2
@@ -637,7 +638,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(4)).write(any(byte[].class), anyInt(), anyInt());
 
     //Test command yarn application -list --appStates with invalid appStates
@@ -659,7 +660,7 @@ public class TestYarnCLI {
     pw.println(output.substring(0, output.length()-1));
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(4)).write(any(byte[].class), anyInt(), anyInt());
 
     //Test command yarn application -list --appStates all
@@ -718,7 +719,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(5)).write(any(byte[].class), anyInt(), anyInt());
 
     // Test command yarn application user case insensitive
@@ -754,7 +755,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(6)).write(any(byte[].class), anyInt(), anyInt());
 
     // Test command yarn application with tags.
@@ -788,7 +789,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(7)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -828,7 +829,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(8)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -857,7 +858,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(9)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -888,7 +889,7 @@ public class TestYarnCLI {
     pw.println("\t                                N/A");
     pw.close();
     appsReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(appsReportStr, sysOutStream.toString());
+    Assertions.assertEquals(appsReportStr, sysOutStream.toString());
     verify(sysOut, times(10)).write(any(byte[].class), anyInt(), anyInt());
   }
 
@@ -938,14 +939,15 @@ public class TestYarnCLI {
     return appReports;
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testAppsHelpCommand() throws Exception {
     ApplicationCLI cli = createAndGetAppCLI();
     ApplicationCLI spyCli = spy(cli);
     int result = spyCli.run(new String[] { "application", "-help" });
-    Assert.assertTrue(result == 0);
+    Assertions.assertTrue(result == 0);
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createApplicationCLIHelpMessage(),
+    Assertions.assertEquals(createApplicationCLIHelpMessage(),
         sysOutStream.toString());
 
     sysOutStream.reset();
@@ -953,18 +955,19 @@ public class TestYarnCLI {
     result = cli.run(
         new String[] { "application", "-status", nodeId.toString(), "args" });
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createApplicationCLIHelpMessage(),
+    Assertions.assertEquals(createApplicationCLIHelpMessage(),
         sysOutStream.toString());
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testAppAttemptsHelpCommand() throws Exception {
     ApplicationCLI cli = createAndGetAppCLI();
     ApplicationCLI spyCli = spy(cli);
     int result = spyCli.run(new String[] { "applicationattempt", "-help" });
-    Assert.assertTrue(result == 0);
+    Assertions.assertTrue(result == 0);
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createApplicationAttemptCLIHelpMessage(),
+    Assertions.assertEquals(createApplicationAttemptCLIHelpMessage(),
         sysOutStream.toString());
 
     sysOutStream.reset();
@@ -973,7 +976,7 @@ public class TestYarnCLI {
         new String[] {"applicationattempt", "-list", applicationId.toString(),
             "args" });
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createApplicationAttemptCLIHelpMessage(),
+    Assertions.assertEquals(createApplicationAttemptCLIHelpMessage(),
         sysOutStream.toString());
 
     sysOutStream.reset();
@@ -983,18 +986,19 @@ public class TestYarnCLI {
         new String[] { "applicationattempt", "-status", appAttemptId.toString(),
             "args" });
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createApplicationAttemptCLIHelpMessage(),
+    Assertions.assertEquals(createApplicationAttemptCLIHelpMessage(),
         sysOutStream.toString());
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10)
   public void testContainersHelpCommand() throws Exception {
     ApplicationCLI cli = createAndGetAppCLI();
     ApplicationCLI spyCli = spy(cli);
     int result = spyCli.run(new String[] { "container", "-help" });
-    Assert.assertTrue(result == 0);
+    Assertions.assertTrue(result == 0);
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createContainerCLIHelpMessage(),
+    Assertions.assertEquals(createContainerCLIHelpMessage(),
         normalize(sysOutStream.toString()));
 
     sysOutStream.reset();
@@ -1004,7 +1008,7 @@ public class TestYarnCLI {
     result = cli.run(
         new String[] {"container", "-list", appAttemptId.toString(), "args" });
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createContainerCLIHelpMessage(),
+    Assertions.assertEquals(createContainerCLIHelpMessage(),
         normalize(sysOutStream.toString()));
 
     sysOutStream.reset();
@@ -1012,15 +1016,16 @@ public class TestYarnCLI {
     result = cli.run(
         new String[] { "container", "-status", containerId.toString(), "args" });
     verify(spyCli).printUsage(any(String.class), any(Options.class));
-    Assert.assertEquals(createContainerCLIHelpMessage(),
+    Assertions.assertEquals(createContainerCLIHelpMessage(),
         normalize(sysOutStream.toString()));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5)
   public void testNodesHelpCommand() throws Exception {
     NodeCLI nodeCLI = createAndGetNodeCLI();
     nodeCLI.run(new String[] {});
-    Assert.assertEquals(createNodeCLIHelpMessage(),
+    Assertions.assertEquals(createNodeCLIHelpMessage(),
         sysOutStream.toString());
   }
 
@@ -1063,12 +1068,12 @@ public class TestYarnCLI {
           cli.run(new String[] { "application","-kill", applicationId.toString() });
       verify(sysOut).println("Application with id '" + applicationId +
               "' doesn't exist in RM.");
-      Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+      Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
     } catch (ApplicationNotFoundException appEx) {
-      Assert.fail("application -kill should not throw" +
+      Assertions.fail("application -kill should not throw" +
           "ApplicationNotFoundException. " + appEx);
     } catch (Exception e) {
-      Assert.fail("Unexpected exception: " + e);
+      Assertions.fail("Unexpected exception: " + e);
     }
   }
 
@@ -1139,7 +1144,7 @@ public class TestYarnCLI {
         .getApplicationReport(applicationId4);
     result = cli.run(new String[]{"application", "-kill",
         applicationId3.toString() + " " + applicationId4.toString()});
-    Assert.assertNotEquals(0, result);
+    Assertions.assertNotEquals(0, result);
     verify(sysOut).println(
         "Application with id 'application_1234_0007' doesn't exist in RM.");
     verify(sysOut).println(
@@ -1158,14 +1163,14 @@ public class TestYarnCLI {
         newApplicationReport5);
     result = cli.run(new String[]{"application", "-kill",
         applicationId3.toString() + " " + applicationId1.toString()});
-    Assert.assertEquals(0, result);
+    Assertions.assertEquals(0, result);
 
     // Test Scenario 5: kill operation with some other command.
     sysOutStream.reset();
     result = cli.run(new String[]{"application", "--appStates", "RUNNING",
         "-kill", applicationId3.toString() + " " + applicationId1.toString()});
-    Assert.assertEquals(-1, result);
-    Assert.assertEquals(createApplicationCLIHelpMessage(),
+    Assertions.assertEquals(-1, result);
+    Assertions.assertEquals(createApplicationCLIHelpMessage(),
         sysOutStream.toString());
   }
 
@@ -1241,10 +1246,10 @@ public class TestYarnCLI {
     try {
       result = cli.run(new String[] { "application", "-movetoqueue",
           applicationId.toString(), "-queue", "targetqueue"});
-      Assert.fail();
+      Assertions.fail();
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof ApplicationNotFoundException);
-      Assert.assertEquals("Application with id '" + applicationId +
+      Assertions.assertTrue(ex instanceof ApplicationNotFoundException);
+      Assertions.assertEquals("Application with id '" + applicationId +
           "' doesn't exist in RM.", ex.getMessage());
     }
   }
@@ -1293,10 +1298,10 @@ public class TestYarnCLI {
     try {
       result = cli.run(new String[]{"application", "-appId",
           applicationId.toString(), "-changeQueue", "targetqueue"});
-      Assert.fail();
+      Assertions.fail();
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof ApplicationNotFoundException);
-      Assert.assertEquals(
+      Assertions.assertTrue(ex instanceof ApplicationNotFoundException);
+      Assertions.assertEquals(
           "Application with id '" + applicationId + "' doesn't exist in RM.",
           ex.getMessage());
     }
@@ -1331,7 +1336,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     String nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(1)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1354,13 +1359,13 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(2)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
     result = cli.run(new String[] {"-list"});
     assertEquals(0, result);
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(3)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1389,7 +1394,7 @@ public class TestYarnCLI {
     pw.println("\tNode-Labels : ");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(4)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1410,7 +1415,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(5)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1431,7 +1436,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(6)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1452,7 +1457,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(7)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1473,7 +1478,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(8)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1506,7 +1511,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(9)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1541,7 +1546,7 @@ public class TestYarnCLI {
     pw.println("                           0");
     pw.close();
     nodesReportStr = baos.toString("UTF-8");
-    Assert.assertEquals(nodesReportStr, sysOutStream.toString());
+    Assertions.assertEquals(nodesReportStr, sysOutStream.toString());
     verify(sysOut, times(10)).write(any(byte[].class), anyInt(), anyInt());
 
     sysOutStream.reset();
@@ -1695,26 +1700,26 @@ public class TestYarnCLI {
     ApplicationCLI cli = createAndGetAppCLI();
     int result = cli.run(new String[] { "application", "-status" });
     assertThat(result).isEqualTo(-1);
-    Assert.assertEquals(String.format("Missing argument for options%n%1s",
+    Assertions.assertEquals(String.format("Missing argument for options%n%1s",
         createApplicationCLIHelpMessage()), sysOutStream.toString());
 
     sysOutStream.reset();
     result = cli.run(new String[] { "applicationattempt", "-status" });
     assertThat(result).isEqualTo(-1);
-    Assert.assertEquals(String.format("Missing argument for options%n%1s",
+    Assertions.assertEquals(String.format("Missing argument for options%n%1s",
         createApplicationAttemptCLIHelpMessage()), sysOutStream.toString());
 
     sysOutStream.reset();
     result = cli.run(new String[] { "container", "-status" });
     assertThat(result).isEqualTo(-1);
-    Assert.assertEquals(String.format("Missing argument for options %1s",
+    Assertions.assertEquals(String.format("Missing argument for options %1s",
         createContainerCLIHelpMessage()), normalize(sysOutStream.toString()));
 
     sysOutStream.reset();
     NodeCLI nodeCLI = createAndGetNodeCLI();
     result = nodeCLI.run(new String[] { "-status" });
     assertThat(result).isEqualTo(-1);
-    Assert.assertEquals(String.format("Missing argument for options%n%1s",
+    Assertions.assertEquals(String.format("Missing argument for options%n%1s",
         createNodeCLIHelpMessage()), sysOutStream.toString());
   }
   
@@ -1751,7 +1756,7 @@ public class TestYarnCLI {
     pw.println("\tIntra-queue Preemption : " + "enabled");
     pw.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
 
   @Test
@@ -1775,7 +1780,7 @@ public class TestYarnCLI {
     queueInfos.add(queueInfo3);
     when(client.getAllQueues()).thenReturn(queueInfos);
     int result = cli.run(new String[] {"-list", "all"});
-    Assert.assertEquals(0, result);
+    Assertions.assertEquals(0, result);
     verify(client).getAllQueues();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     PrintWriter writer = new PrintWriter(baos);
@@ -1796,7 +1801,7 @@ public class TestYarnCLI {
     writer.print(formattingCLIUtils.render());
     writer.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
 
   @Test
@@ -1837,10 +1842,10 @@ public class TestYarnCLI {
       int result = cli.run(new String[] { "-status", "a" });
       assertEquals(0, result);
       String queueStatusOut = sysOutStream.toString();
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("\tPreemption : enabled"));
       // In-queue preemption is disabled at the "root.a" queue level
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("Intra-queue Preemption : disabled"));
       cli = createAndGetQueueCLI(yarnClient);
       sysOutStream.reset();
@@ -1848,10 +1853,10 @@ public class TestYarnCLI {
       result = cli.run(new String[] { "-status", "a1" });
       assertEquals(0, result);
       queueStatusOut = sysOutStream.toString();
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("\tPreemption : enabled"));
       // In-queue preemption is enabled at the "root.a.a1" queue level
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("Intra-queue Preemption : enabled"));
     } finally {
       // clean-up
@@ -1892,9 +1897,9 @@ public class TestYarnCLI {
       int result = cli.run(new String[] { "-status", "a1" });
       assertEquals(0, result);
       String queueStatusOut = sysOutStream.toString();
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("\tPreemption : enabled"));
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("Intra-queue Preemption : enabled"));
     } finally {
       // clean-up
@@ -1933,9 +1938,9 @@ public class TestYarnCLI {
       int result = cli.run(new String[] { "-status", "a1" });
       assertEquals(0, result);
       String queueStatusOut = sysOutStream.toString();
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("\tPreemption : disabled"));
-      Assert.assertTrue(queueStatusOut
+      Assertions.assertTrue(queueStatusOut
           .contains("Intra-queue Preemption : disabled"));
     }
   }
@@ -1970,7 +1975,7 @@ public class TestYarnCLI {
     pw.println("\tIntra-queue Preemption : " + "disabled");
     pw.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
 
   @Test
@@ -2014,7 +2019,7 @@ public class TestYarnCLI {
     pw.println("\tQueue Preemption : enabled");
     pw.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
 
   @Test
@@ -2062,7 +2067,7 @@ public class TestYarnCLI {
     pw.println("\tQueue Preemption : " + "enabled");
     pw.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
   
   @Test
@@ -2078,7 +2083,7 @@ public class TestYarnCLI {
         + ", please check.");
     pw.close();
     String queueInfoStr = baos.toString("UTF-8");
-    Assert.assertEquals(queueInfoStr, sysOutStream.toString());
+    Assertions.assertEquals(queueInfoStr, sysOutStream.toString());
   }
 
   @Test
@@ -2096,7 +2101,7 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Application for AppAttempt with id '" + attemptId1
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
 
     ApplicationAttemptId attemptId2 = ApplicationAttemptId.newInstance(
         applicationId, 2);
@@ -2110,7 +2115,7 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Application Attempt with id '" + attemptId2
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
   }
 
   @Test
@@ -2130,7 +2135,7 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Application for Container with id '" + containerId1
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
     ContainerId containerId2 = ContainerId.newContainerId(attemptId, cntId++);
     when(client.getContainerReport(containerId2)).thenThrow(
         new ApplicationAttemptNotFoundException(
@@ -2142,7 +2147,7 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Application Attempt for Container with id '" + containerId2
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
 
     ContainerId containerId3 = ContainerId.newContainerId(attemptId, cntId++);
     when(client.getContainerReport(containerId3)).thenThrow(
@@ -2153,10 +2158,11 @@ public class TestYarnCLI {
     verify(sysOut).println(
         "Container with id '" + containerId3
             + "' doesn't exist in RM or Timeline Server.");
-    Assert.assertNotSame("should return non-zero exit code.", 0, exitCode);
+    Assertions.assertNotSame(0, exitCode, "should return non-zero exit code.");
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateApplicationPriority() throws Exception {
     ApplicationCLI cli = createAndGetAppCLI();
     ApplicationId applicationId = ApplicationId.newInstance(1234, 6);
@@ -2186,7 +2192,7 @@ public class TestYarnCLI {
     ApplicationCLI cli = createAndGetAppCLI();
     int exitCode = cli.run(new String[] {"applicationattempt", "-fail",
         "appattempt_1444199730803_0003_000001"});
-    Assert.assertEquals(0, exitCode);
+    Assertions.assertEquals(0, exitCode);
 
     verify(client).failApplicationAttempt(any(ApplicationAttemptId.class));
     verifyNoMoreInteractions(client);
@@ -2552,7 +2558,8 @@ public class TestYarnCLI {
     assertEquals(0, result);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testUpdateApplicationTimeout() throws Exception {
     ApplicationCLI cli = createAndGetAppCLI();
     ApplicationId applicationId = ApplicationId.newInstance(1234, 6);

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/util/TestFormattingCLIUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/util/TestFormattingCLIUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.yarn.client.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -28,7 +28,7 @@ import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFormattingCLIUtils {
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/util/TestYarnClientUtils.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-client/src/test/java/org/apache/hadoop/yarn/client/util/TestYarnClientUtils.java
@@ -24,8 +24,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for the YarnClientUtils class
@@ -46,8 +46,8 @@ public class TestYarnClientUtils {
 
     String result = YarnClientUtils.getRmPrincipal(conf);
 
-    assertNull("The hostname translation did return null when the principal is "
-        + "missing from the conf: " + result, result);
+    assertNull(result, "The hostname translation did return null when the principal is "
+        + "missing from the conf: " + result);
 
     conf = new Configuration();
 
@@ -83,8 +83,8 @@ public class TestYarnClientUtils {
 
     String result = YarnClientUtils.getRmPrincipal(conf);
 
-    assertNull("The hostname translation did return null when the principal is "
-        + "missing from the conf: " + result, result);
+    assertNull(result, "The hostname translation did return null when the principal is "
+        + "missing from the conf: " + result);
 
     conf = new Configuration();
 
@@ -298,8 +298,8 @@ public class TestYarnClientUtils {
       if (!seen.add(key)) {
         // Here we use master.get() instead of property.getValue() because
         // they're not the same thing.
-        assertEquals("New configuration changed the value of "
-            + key, master.get(key), copy.get(key));
+        assertEquals(master.get(key), copy.get(key), "New configuration changed the value of "
+            + key);
       }
     }
 
@@ -310,9 +310,9 @@ public class TestYarnClientUtils {
       String key = property.getKey();
 
       if (!seen.contains(property.getKey())) {
-        assertEquals("New configuration changed the value of "
-            + key, copy.get(key),
-            master.get(key));
+        assertEquals(copy.get(key)
+,             master.get(key), "New configuration changed the value of "
+            + key);
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

JIRA: YARN-11244. Upgrade JUnit from 4 to 5 in hadoop-yarn-client.

### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

